### PR TITLE
Added explicity operator= and copy constructor when other one already…

### DIFF
--- a/KEMField/Source/FastMultipole/Electrostatics/include/KFMElectrostaticLocalCoefficientSet.hh
+++ b/KEMField/Source/FastMultipole/Electrostatics/include/KFMElectrostaticLocalCoefficientSet.hh
@@ -25,6 +25,11 @@ class KFMElectrostaticLocalCoefficientSet: public KFMScalarMultipoleExpansion
         KFMElectrostaticLocalCoefficientSet();
         virtual ~KFMElectrostaticLocalCoefficientSet();
         KFMElectrostaticLocalCoefficientSet(const KFMElectrostaticLocalCoefficientSet &copyObject):KFMScalarMultipoleExpansion(copyObject){;};
+        KFMElectrostaticLocalCoefficientSet& operator=(const KFMElectrostaticLocalCoefficientSet &copyObject)
+        {
+            KFMScalarMultipoleExpansion::operator=(copyObject);
+            return *this;
+        };
 
         virtual std::string ClassName() const;
 

--- a/KEMField/Source/FastMultipole/Electrostatics/include/KFMElectrostaticMultipoleSet.hh
+++ b/KEMField/Source/FastMultipole/Electrostatics/include/KFMElectrostaticMultipoleSet.hh
@@ -25,6 +25,11 @@ class KFMElectrostaticMultipoleSet: public KFMScalarMultipoleExpansion
         KFMElectrostaticMultipoleSet();
         virtual ~KFMElectrostaticMultipoleSet();
         KFMElectrostaticMultipoleSet(const KFMElectrostaticMultipoleSet &copyObject):KFMScalarMultipoleExpansion(copyObject){;};
+        KFMElectrostaticMultipoleSet& operator=(const KFMElectrostaticMultipoleSet &copyObject)
+        {
+            KFMScalarMultipoleExpansion::operator=(copyObject);
+            return *this;
+        };
 
         virtual std::string ClassName() const;
 

--- a/KEMField/Source/FastMultipole/Math/include/KFMPointCloud.hh
+++ b/KEMField/Source/FastMultipole/Math/include/KFMPointCloud.hh
@@ -37,6 +37,15 @@ class KFMPointCloud
             }
         }
 
+        KFMPointCloud& operator=(const KFMPointCloud& copyObject)
+        {
+            if(&copyObject != this)
+            {
+                fPoints = copyObject.fPoints;
+            }
+            return *this;
+        }
+
         unsigned int GetNPoints() const
         {
             return fPoints.size();

--- a/KGeoBag/Source/Extensions/Appearance/Include/KGRGBAColor.hh
+++ b/KGeoBag/Source/Extensions/Appearance/Include/KGRGBAColor.hh
@@ -15,6 +15,17 @@ namespace KGeoBag
             KGRGBAColor( int aRed, int aGreen, int aBlue, int anOpacity );
             virtual ~KGRGBAColor();
 
+            //assignment
+            inline KGRGBAColor& operator=(const KGRGBAColor& c)
+            {
+                if(&c != this)
+                {
+                    KGRGBColor::operator=( c );
+                    fOpacity = c.fOpacity;
+                }
+                return *this;
+            }
+
             void SetOpacity( const unsigned char& anOpacity );
             const unsigned char& GetOpacity() const;
 

--- a/KGeoBag/Source/Extensions/Appearance/Include/KGRGBColor.hh
+++ b/KGeoBag/Source/Extensions/Appearance/Include/KGRGBColor.hh
@@ -21,6 +21,18 @@ namespace KGeoBag
             KGRGBColor( int aRed, int aGreen, int aBlue );
             virtual ~KGRGBColor();
 
+            //assignment
+            inline KGRGBColor& operator=(const KGRGBColor& c)
+            {
+                if(&c != this)
+                {
+                    fRed = c.fRed;
+                    fGreen = c.fGreen;
+                    fBlue = c.fBlue;
+                }
+                return *this;
+            }
+
             void SetRed( const unsigned char& aRed );
             const unsigned char& GetRed() const;
 

--- a/KGeoBag/Source/Extensions/Mesh/Include/KGMeshRectangle.hh
+++ b/KGeoBag/Source/Extensions/Mesh/Include/KGMeshRectangle.hh
@@ -13,6 +13,7 @@ namespace KGeoBag
         public:
             KGMeshRectangle( const double& a, const double& b, const KThreeVector& p0, const KThreeVector& n1, const KThreeVector& n2 );
             KGMeshRectangle( const KThreeVector& p0, const KThreeVector& p1, const KThreeVector& /*p2*/, const KThreeVector& p3 );
+            KGMeshRectangle( const KGMeshRectangle& r );
             virtual ~KGMeshRectangle();
 
             double Area() const;

--- a/KGeoBag/Source/Extensions/Mesh/Include/KGMeshTriangle.hh
+++ b/KGeoBag/Source/Extensions/Mesh/Include/KGMeshTriangle.hh
@@ -13,6 +13,7 @@ namespace KGeoBag
         public:
             KGMeshTriangle( const double& a, const double& b, const KThreeVector& p0, const KThreeVector& n1, const KThreeVector& n2 );
             KGMeshTriangle( const KThreeVector& p0, const KThreeVector& p1, const KThreeVector& p2 );
+            KGMeshTriangle( const KGMeshTriangle& t );
             virtual ~KGMeshTriangle();
 
             double Area() const;

--- a/KGeoBag/Source/Extensions/Mesh/Source/KGMeshRectangle.cc
+++ b/KGeoBag/Source/Extensions/Mesh/Source/KGMeshRectangle.cc
@@ -29,6 +29,15 @@ namespace KGeoBag
         fB = fN2.Magnitude();
         fN2 = fN2.Unit();
     }
+    KGMeshRectangle::KGMeshRectangle( const KGMeshRectangle& r ) :
+            KGMeshElement( r ),
+            fA( r.fA ),
+            fB( r.fB ),
+            fP0( r.fP0 ),
+            fN1( r.fN1 ),
+            fN2( r.fN2 )
+    {
+    }
     KGMeshRectangle::~KGMeshRectangle()
     {
     }

--- a/KGeoBag/Source/Extensions/Mesh/Source/KGMeshTriangle.cc
+++ b/KGeoBag/Source/Extensions/Mesh/Source/KGMeshTriangle.cc
@@ -29,6 +29,15 @@ namespace KGeoBag
         fB = fN2.Magnitude();
         fN2 = fN2.Unit();
     }
+    KGMeshTriangle::KGMeshTriangle( const KGMeshTriangle& t ) :
+            KGMeshElement( t ),
+            fA( t.fA ),
+            fB( t.fB ),
+            fP0( t.fP0 ),
+            fN1( t.fN1 ),
+            fN2( t.fN2 )
+    {
+    }
     KGMeshTriangle::~KGMeshTriangle()
     {
     }

--- a/Kassiopeia/Math/Include/KSMathArray.h
+++ b/Kassiopeia/Math/Include/KSMathArray.h
@@ -135,6 +135,13 @@ namespace Kassiopeia
             {
                 (*this) = (0.);
             }
+            KSMathArray( const KSMathArray& anOperand )
+            {
+                for( int Index = 0; Index < sDimension; Index++ )
+                {
+                    fData[Index] = anOperand.fData[Index];
+                }
+            }
             virtual ~KSMathArray()
             {
             }

--- a/Kassiopeia/Trajectories/Include/KSTrajAdiabaticDerivative.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajAdiabaticDerivative.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajAdiabaticDerivative();
+            KSTrajAdiabaticDerivative( const KSTrajAdiabaticDerivative& anOperand );
             virtual ~KSTrajAdiabaticDerivative();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajAdiabaticError.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajAdiabaticError.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajAdiabaticError();
+            KSTrajAdiabaticError( const KSTrajAdiabaticError& anOperand );
             virtual ~KSTrajAdiabaticError();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajAdiabaticParticle.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajAdiabaticParticle.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajAdiabaticParticle();
+            KSTrajAdiabaticParticle( const KSTrajAdiabaticParticle& aParticle );
             ~KSTrajAdiabaticParticle();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajAdiabaticSpinDerivative.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajAdiabaticSpinDerivative.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajAdiabaticSpinDerivative();
+            KSTrajAdiabaticSpinDerivative( const KSTrajAdiabaticSpinDerivative& anOperand );
             virtual ~KSTrajAdiabaticSpinDerivative();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajAdiabaticSpinError.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajAdiabaticSpinError.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajAdiabaticSpinError();
+            KSTrajAdiabaticSpinError( const KSTrajAdiabaticSpinError& anOperand );
             ~KSTrajAdiabaticSpinError();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajAdiabaticSpinParticle.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajAdiabaticSpinParticle.h
@@ -12,6 +12,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajAdiabaticSpinParticle();
+            KSTrajAdiabaticSpinParticle( const KSTrajAdiabaticSpinParticle& aParticle );
             ~KSTrajAdiabaticSpinParticle();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajElectricDerivative.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajElectricDerivative.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajElectricDerivative();
+            KSTrajElectricDerivative( const KSTrajElectricDerivative& anOperand );
             virtual ~KSTrajElectricDerivative();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajElectricError.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajElectricError.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajElectricError();
+            KSTrajElectricError( const KSTrajElectricError& anOperand );
             virtual ~KSTrajElectricError();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajElectricParticle.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajElectricParticle.h
@@ -12,6 +12,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajElectricParticle();
+            KSTrajElectricParticle( const KSTrajElectricParticle& aParticle );
             ~KSTrajElectricParticle();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactDerivative.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactDerivative.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactDerivative();
+            KSTrajExactDerivative( const KSTrajExactDerivative& anOperand );
             virtual ~KSTrajExactDerivative();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactError.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactError.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactError();
+            KSTrajExactError( const KSTrajExactError& anOperand );
             ~KSTrajExactError();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactParticle.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactParticle.h
@@ -12,6 +12,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactParticle();
+            KSTrajExactParticle( const KSTrajExactParticle& aParticle );
             ~KSTrajExactParticle();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactSpinDerivative.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactSpinDerivative.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactSpinDerivative();
+            KSTrajExactSpinDerivative( const KSTrajExactSpinDerivative& anOperand );
             virtual ~KSTrajExactSpinDerivative();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactSpinError.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactSpinError.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactSpinError();
+            KSTrajExactSpinError( const KSTrajExactSpinError& anOperand );
             ~KSTrajExactSpinError();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactSpinParticle.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactSpinParticle.h
@@ -12,6 +12,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactSpinParticle();
+            KSTrajExactSpinParticle( const KSTrajExactSpinParticle& aParticle );
             ~KSTrajExactSpinParticle();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactTrappedDerivative.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactTrappedDerivative.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactTrappedDerivative();
+            KSTrajExactTrappedDerivative( const KSTrajExactTrappedDerivative& anOperand );
             virtual ~KSTrajExactTrappedDerivative();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactTrappedError.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactTrappedError.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactTrappedError();
+            KSTrajExactTrappedError( const KSTrajExactTrappedError& anOperand );
             ~KSTrajExactTrappedError();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajExactTrappedParticle.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajExactTrappedParticle.h
@@ -12,6 +12,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajExactTrappedParticle();
+            KSTrajExactTrappedParticle( const KSTrajExactTrappedParticle& anOperand );
             ~KSTrajExactTrappedParticle();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajMagneticDerivative.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajMagneticDerivative.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajMagneticDerivative();
+            KSTrajMagneticDerivative( const KSTrajMagneticDerivative& anOperand );
             virtual ~KSTrajMagneticDerivative();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajMagneticError.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajMagneticError.h
@@ -14,6 +14,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajMagneticError();
+            KSTrajMagneticError( const KSTrajMagneticError& anOperand );
             virtual ~KSTrajMagneticError();
 
             //**********

--- a/Kassiopeia/Trajectories/Include/KSTrajMagneticParticle.h
+++ b/Kassiopeia/Trajectories/Include/KSTrajMagneticParticle.h
@@ -12,6 +12,7 @@ namespace Kassiopeia
     {
         public:
             KSTrajMagneticParticle();
+            KSTrajMagneticParticle( const KSTrajMagneticParticle& aParticle );
             ~KSTrajMagneticParticle();
 
             //**********

--- a/Kassiopeia/Trajectories/Source/KSTrajAdiabaticDerivative.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajAdiabaticDerivative.cxx
@@ -6,6 +6,10 @@ namespace Kassiopeia
     KSTrajAdiabaticDerivative::KSTrajAdiabaticDerivative()
     {
     }
+    KSTrajAdiabaticDerivative::KSTrajAdiabaticDerivative( const KSTrajAdiabaticDerivative& anOperand ) :
+        KSMathArray<8>( anOperand )
+    {
+    }
     KSTrajAdiabaticDerivative::~KSTrajAdiabaticDerivative()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajAdiabaticError.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajAdiabaticError.cxx
@@ -14,6 +14,10 @@ namespace Kassiopeia
             fPhaseError( 0. )
     {
     }
+    KSTrajAdiabaticError::KSTrajAdiabaticError( const KSTrajAdiabaticError& anOperand ) :
+        KSMathArray< 8 >( anOperand )
+    {
+    }
     KSTrajAdiabaticError::~KSTrajAdiabaticError()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajAdiabaticParticle.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajAdiabaticParticle.cxx
@@ -60,7 +60,46 @@ namespace Kassiopeia
             fGetElectricPotentialPtr( &KSTrajAdiabaticParticle::RecalculateElectricPotential ),
             fGetElectricPotentialRPPtr( &KSTrajAdiabaticParticle::RecalculateElectricPotentialRP ),
             fGetElectricFieldAndPotentialPtr( &KSTrajAdiabaticParticle::RecalculateElectricFieldAndPotential )
+    {
+    }
+    KSTrajAdiabaticParticle::KSTrajAdiabaticParticle( const KSTrajAdiabaticParticle& aParticle) :
+            KSMathArray<8>( aParticle ),
+            fTime( aParticle.fTime ),
+            fLength( aParticle.fLength ),
+            fPosition( aParticle.fPosition ),
+            fMomentum( aParticle.fMomentum ),
+            fVelocity( aParticle.fVelocity ),
+            fLorentzFactor( aParticle.fLorentzFactor ),
+            fKineticEnergy( aParticle.fKineticEnergy ),
 
+            fMagneticField( aParticle.fMagneticField ),
+            fElectricField( aParticle.fElectricField ),
+            fMagneticGradient( aParticle.fMagneticGradient ),
+            fElectricPotential( aParticle.fElectricPotential ),
+            fElectricPotentialRP( aParticle.fElectricPotentialRP ),
+
+            fGuidingCenter( aParticle.fGuidingCenter ),
+            fLongMomentum( aParticle.fLongMomentum ),
+            fTransMomentum( aParticle.fTransMomentum ),
+            fLongVelocity( aParticle.fLongVelocity ),
+            fTransVelocity( aParticle.fTransVelocity ),
+            fCyclotronFrequency( aParticle.fCyclotronFrequency ),
+            fOrbitalMagneticMoment( aParticle.fOrbitalMagneticMoment ),
+
+            fAlpha( aParticle.fAlpha ),
+            fBeta( aParticle.fBeta ),
+            fLastTime( aParticle.fLastTime ),
+            fLastPosition( aParticle.fLastPosition ),
+            fLastMomentum( aParticle.fLastMomentum ),
+            fPhase( aParticle.fPhase ),
+
+            fGetMagneticFieldPtr( aParticle.fGetMagneticFieldPtr ),
+            fGetElectricFieldPtr( aParticle.fGetElectricFieldPtr ),
+            fGetMagneticGradientPtr( aParticle.fGetMagneticGradientPtr ),
+            fGetMagneticFieldAndGradientPtr( aParticle.fGetMagneticFieldAndGradientPtr ),
+            fGetElectricPotentialPtr( aParticle.fGetElectricPotentialPtr ),
+            fGetElectricPotentialRPPtr( aParticle.fGetElectricPotentialRPPtr ),
+            fGetElectricFieldAndPotentialPtr( aParticle.fGetElectricFieldAndPotentialPtr )
     {
     }
     KSTrajAdiabaticParticle::~KSTrajAdiabaticParticle()

--- a/Kassiopeia/Trajectories/Source/KSTrajAdiabaticSpinDerivative.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajAdiabaticSpinDerivative.cxx
@@ -6,6 +6,10 @@ namespace Kassiopeia
     KSTrajAdiabaticSpinDerivative::KSTrajAdiabaticSpinDerivative()
     {
     }
+    KSTrajAdiabaticSpinDerivative::KSTrajAdiabaticSpinDerivative( const KSTrajAdiabaticSpinDerivative& anOperand ) :
+        KSMathArray<10>( anOperand )
+    {
+    }
     KSTrajAdiabaticSpinDerivative::~KSTrajAdiabaticSpinDerivative()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajAdiabaticSpinError.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajAdiabaticSpinError.cxx
@@ -11,6 +11,11 @@ namespace Kassiopeia
     {
     }
 
+    KSTrajAdiabaticSpinError::KSTrajAdiabaticSpinError( const KSTrajAdiabaticSpinError& anOperand ) :
+        KSMathArray< 10 >( anOperand )
+    {
+    }
+
     KSTrajAdiabaticSpinError::~KSTrajAdiabaticSpinError()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajAdiabaticSpinParticle.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajAdiabaticSpinParticle.cxx
@@ -60,6 +60,40 @@ namespace Kassiopeia
             fGetElectricGradientPtr( &KSTrajAdiabaticSpinParticle::RecalculateElectricGradient )
     {
     }
+    KSTrajAdiabaticSpinParticle::KSTrajAdiabaticSpinParticle( const KSTrajAdiabaticSpinParticle& aParticle ) :
+            KSMathArray<10>( aParticle ),
+            fTime( aParticle.fTime ),
+            fLength( aParticle.fLength ),
+            fPosition( aParticle.fPosition ),
+            fMomentum( aParticle.fMomentum ),
+            fVelocity( aParticle.fVelocity ),
+            fLorentzFactor( aParticle.fLorentzFactor ),
+            fKineticEnergy( aParticle.fKineticEnergy ),
+
+            fMagneticField( aParticle.fMagneticField ),
+            fElectricField( aParticle.fElectricField ),
+            fMagneticGradient( aParticle.fMagneticGradient ),
+            fElectricGradient( aParticle.fElectricGradient ),
+            fElectricPotential( aParticle.fElectricPotential ),
+
+            fGuidingCenter( aParticle.fGuidingCenter ),
+            fLongMomentum( aParticle.fLongMomentum ),
+            fTransMomentum( aParticle.fTransMomentum ),
+            fLongVelocity( aParticle.fLongVelocity ),
+            fTransVelocity( aParticle.fTransVelocity ),
+            fCyclotronFrequency( aParticle.fCyclotronFrequency ),
+            fOrbitalMagneticMoment( aParticle.fOrbitalMagneticMoment ),
+
+            fAlignedSpin( aParticle.fAlignedSpin ),
+            fSpinAngle( aParticle.fSpinAngle ),
+
+            fGetMagneticFieldPtr( aParticle.fGetMagneticFieldPtr ),
+            fGetElectricFieldPtr( aParticle.fGetElectricFieldPtr ),
+            fGetMagneticGradientPtr( aParticle.fGetMagneticGradientPtr ),
+            fGetElectricPotentialPtr( aParticle.fGetElectricPotentialPtr ),
+            fGetElectricGradientPtr( aParticle.fGetElectricGradientPtr )
+    {
+    }
     KSTrajAdiabaticSpinParticle::~KSTrajAdiabaticSpinParticle()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajElectricDerivative.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajElectricDerivative.cxx
@@ -6,6 +6,10 @@ namespace Kassiopeia
     KSTrajElectricDerivative::KSTrajElectricDerivative()
     {
     }
+    KSTrajElectricDerivative::KSTrajElectricDerivative( const KSTrajElectricDerivative& anOperand ) :
+        KSMathArray<5>( anOperand )
+    {
+    }
     KSTrajElectricDerivative::~KSTrajElectricDerivative()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajElectricError.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajElectricError.cxx
@@ -12,6 +12,11 @@ namespace Kassiopeia
     {
     }
 
+    KSTrajElectricError::KSTrajElectricError( const KSTrajElectricError& anOperand ) :
+         KSMathArray< 5 >( anOperand )
+    {
+    }
+
     KSTrajElectricError::~KSTrajElectricError()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajElectricParticle.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajElectricParticle.cxx
@@ -48,6 +48,35 @@ namespace Kassiopeia
             fGetElectricPotentialPtr( &KSTrajElectricParticle::RecalculateElectricPotential )
     {
     }
+    KSTrajElectricParticle::KSTrajElectricParticle( const KSTrajElectricParticle& aParticle ) :
+            KSMathArray<5>( aParticle ),
+            fTime( aParticle.fTime ),
+            fLength( aParticle.fLength ),
+            fPosition( aParticle.fPosition ),
+            fMomentum( aParticle.fMomentum ),
+            fVelocity( aParticle.fVelocity ),
+            fLorentzFactor( aParticle.fLorentzFactor ),
+            fKineticEnergy( aParticle.fKineticEnergy ),
+
+            fMagneticField( aParticle.fMagneticField ),
+            fElectricField( aParticle.fElectricField ),
+            fMagneticGradient( aParticle.fMagneticGradient ),
+            fElectricPotential( aParticle.fElectricPotential ),
+
+            fGuidingCenter( aParticle.fGuidingCenter ),
+            fLongMomentum( aParticle.fLongMomentum ),
+            fTransMomentum( aParticle.fTransMomentum ),
+            fLongVelocity( aParticle.fLongVelocity ),
+            fTransVelocity( aParticle.fTransVelocity ),
+            fCyclotronFrequency( aParticle.fCyclotronFrequency ),
+            fOrbitalMagneticMoment( aParticle.fOrbitalMagneticMoment ),
+
+            fGetMagneticFieldPtr( aParticle.fGetMagneticFieldPtr ),
+            fGetElectricFieldPtr( aParticle.fGetElectricFieldPtr ),
+            fGetMagneticGradientPtr( aParticle.fGetMagneticGradientPtr ),
+            fGetElectricPotentialPtr( aParticle.fGetElectricPotentialPtr )
+    {
+    }
     KSTrajElectricParticle::~KSTrajElectricParticle()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactDerivative.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactDerivative.cxx
@@ -6,6 +6,10 @@ namespace Kassiopeia
     KSTrajExactDerivative::KSTrajExactDerivative()
     {
     }
+    KSTrajExactDerivative::KSTrajExactDerivative( const KSTrajExactDerivative& anOperand ) :
+        KSMathArray<8>( anOperand )
+    {
+    }
     KSTrajExactDerivative::~KSTrajExactDerivative()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactError.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactError.cxx
@@ -11,6 +11,11 @@ namespace Kassiopeia
     {
     }
 
+    KSTrajExactError::KSTrajExactError( const KSTrajExactError& anOperand ) :
+        KSMathArray< 8 >( anOperand )
+    {
+    }
+
     KSTrajExactError::~KSTrajExactError()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactParticle.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactParticle.cxx
@@ -53,6 +53,37 @@ namespace Kassiopeia
             fGetElectricGradientPtr( &KSTrajExactParticle::RecalculateElectricGradient )
     {
     }
+    KSTrajExactParticle::KSTrajExactParticle( const KSTrajExactParticle& aParticle ) :
+            KSMathArray<8>( aParticle ),
+            fTime( aParticle.fTime ),
+            fLength( aParticle.fLength ),
+            fPosition( aParticle.fPosition ),
+            fMomentum( aParticle.fMomentum ),
+            fVelocity( aParticle.fVelocity ),
+            fLorentzFactor( aParticle.fLorentzFactor ),
+            fKineticEnergy( aParticle.fKineticEnergy ),
+
+            fMagneticField( aParticle.fMagneticField ),
+            fElectricField( aParticle.fElectricField ),
+            fMagneticGradient( aParticle.fMagneticGradient ),
+            fElectricGradient( aParticle.fElectricGradient ),
+            fElectricPotential( aParticle.fElectricPotential ),
+
+            fGuidingCenter( aParticle.fGuidingCenter ),
+            fLongMomentum( aParticle.fLongMomentum ),
+            fTransMomentum( aParticle.fTransMomentum ),
+            fLongVelocity( aParticle.fLongVelocity ),
+            fTransVelocity( aParticle.fTransVelocity ),
+            fCyclotronFrequency( aParticle.fCyclotronFrequency ),
+            fOrbitalMagneticMoment( aParticle.fOrbitalMagneticMoment ),
+
+            fGetMagneticFieldPtr( aParticle.fGetMagneticFieldPtr ),
+            fGetElectricFieldPtr( aParticle.fGetElectricFieldPtr ),
+            fGetMagneticGradientPtr( aParticle.fGetMagneticGradientPtr ),
+            fGetElectricPotentialPtr( aParticle.fGetElectricPotentialPtr ),
+            fGetElectricGradientPtr( aParticle.fGetElectricGradientPtr)
+    {
+    }
     KSTrajExactParticle::~KSTrajExactParticle()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactSpinDerivative.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactSpinDerivative.cxx
@@ -6,6 +6,10 @@ namespace Kassiopeia
     KSTrajExactSpinDerivative::KSTrajExactSpinDerivative()
     {
     }
+    KSTrajExactSpinDerivative::KSTrajExactSpinDerivative( const KSTrajExactSpinDerivative& anOperand ) :
+        KSMathArray<12>( anOperand )
+    {
+    }
     KSTrajExactSpinDerivative::~KSTrajExactSpinDerivative()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactSpinError.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactSpinError.cxx
@@ -13,6 +13,11 @@ namespace Kassiopeia
     {
     }
 
+    KSTrajExactSpinError::KSTrajExactSpinError( const KSTrajExactSpinError& anOperand ) :
+        KSMathArray< 12 >( anOperand )
+    {
+    }
+
     KSTrajExactSpinError::~KSTrajExactSpinError()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactSpinParticle.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactSpinParticle.cxx
@@ -57,6 +57,38 @@ namespace Kassiopeia
             fGetElectricPotentialPtr( &KSTrajExactSpinParticle::RecalculateElectricPotential )
     {
     }
+    KSTrajExactSpinParticle::KSTrajExactSpinParticle( const KSTrajExactSpinParticle& aParticle ) :
+            KSMathArray<12>( aParticle ),
+            fTime( aParticle.fTime ),
+            fLength( aParticle.fLength ),
+            fPosition( aParticle.fPosition ),
+            fMomentum( aParticle.fMomentum ),
+            fVelocity( aParticle.fVelocity ),
+            fSpin0( aParticle.fSpin0 ),
+            fSpin( aParticle.fSpin ),
+            fLorentzFactor( aParticle.fLorentzFactor ),
+            fKineticEnergy( aParticle.fKineticEnergy ),
+
+            fMagneticField( aParticle.fMagneticField ),
+            fElectricField( aParticle.fElectricField ),
+            fMagneticGradient( aParticle.fMagneticGradient ),
+            fElectricPotential( aParticle.fElectricPotential ),
+
+            fGuidingCenter( aParticle.fGuidingCenter ),
+            fLongMomentum( aParticle.fLongMomentum ),
+            fTransMomentum( aParticle.fTransMomentum ),
+            fLongVelocity( aParticle.fLongVelocity ),
+            fTransVelocity( aParticle.fTransVelocity ),
+            fCyclotronFrequency( aParticle.fCyclotronFrequency ),
+            fSpinPrecessionFrequency( aParticle.fSpinPrecessionFrequency ),
+            fOrbitalMagneticMoment( aParticle.fOrbitalMagneticMoment ),
+
+            fGetMagneticFieldPtr( aParticle.fGetMagneticFieldPtr ),
+            fGetElectricFieldPtr( aParticle.fGetElectricFieldPtr ),
+            fGetMagneticGradientPtr( aParticle.fGetMagneticGradientPtr ),
+            fGetElectricPotentialPtr( aParticle.fGetElectricPotentialPtr )
+    {
+    }
     KSTrajExactSpinParticle::~KSTrajExactSpinParticle()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactTrappedDerivative.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactTrappedDerivative.cxx
@@ -6,6 +6,10 @@ namespace Kassiopeia
     KSTrajExactTrappedDerivative::KSTrajExactTrappedDerivative()
     {
     }
+    KSTrajExactTrappedDerivative::KSTrajExactTrappedDerivative( const KSTrajExactTrappedDerivative& anOperand ) :
+        KSMathArray<8>( anOperand )
+    {
+    }
     KSTrajExactTrappedDerivative::~KSTrajExactTrappedDerivative()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactTrappedError.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactTrappedError.cxx
@@ -11,6 +11,11 @@ namespace Kassiopeia
     {
     }
 
+    KSTrajExactTrappedError::KSTrajExactTrappedError( const KSTrajExactTrappedError& anOperand ) :
+        KSMathArray< 8 >( anOperand )
+    {
+    }
+
     KSTrajExactTrappedError::~KSTrajExactTrappedError()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajExactTrappedParticle.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajExactTrappedParticle.cxx
@@ -53,6 +53,37 @@ namespace Kassiopeia
             fGetElectricGradientPtr( &KSTrajExactTrappedParticle::RecalculateElectricGradient )
     {
     }
+    KSTrajExactTrappedParticle::KSTrajExactTrappedParticle( const KSTrajExactTrappedParticle& aParticle ) :
+            KSMathArray< 8 >( aParticle ),
+            fTime( aParticle.fTime ),
+            fLength( aParticle.fLength ),
+            fPosition( aParticle.fPosition ),
+            fMomentum( aParticle.fMomentum ),
+            fVelocity( aParticle.fVelocity ),
+            fLorentzFactor( aParticle.fLorentzFactor ),
+            fKineticEnergy( aParticle.fKineticEnergy ),
+
+            fMagneticField( aParticle.fMagneticField ),
+            fElectricField( aParticle.fElectricField ),
+            fMagneticGradient( aParticle.fMagneticGradient ),
+            fElectricGradient( aParticle.fElectricGradient ),
+            fElectricPotential( aParticle.fElectricPotential ),
+
+            fGuidingCenter( aParticle.fGuidingCenter ),
+            fLongMomentum( aParticle.fLongMomentum ),
+            fTransMomentum( aParticle.fTransMomentum ),
+            fLongVelocity( aParticle.fLongVelocity ),
+            fTransVelocity( aParticle.fTransVelocity ),
+            fCyclotronFrequency( aParticle.fCyclotronFrequency ),
+            fOrbitalMagneticMoment( aParticle.fOrbitalMagneticMoment ),
+
+            fGetMagneticFieldPtr( aParticle.fGetMagneticFieldPtr ),
+            fGetElectricFieldPtr( aParticle.fGetElectricFieldPtr ),
+            fGetMagneticGradientPtr( aParticle.fGetMagneticGradientPtr ),
+            fGetElectricPotentialPtr( aParticle.fGetElectricPotentialPtr ),
+            fGetElectricGradientPtr( aParticle.fGetElectricGradientPtr )
+    {
+    }
     KSTrajExactTrappedParticle::~KSTrajExactTrappedParticle()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajMagneticDerivative.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajMagneticDerivative.cxx
@@ -6,6 +6,10 @@ namespace Kassiopeia
     KSTrajMagneticDerivative::KSTrajMagneticDerivative()
     {
     }
+    KSTrajMagneticDerivative::KSTrajMagneticDerivative( const KSTrajMagneticDerivative& anOperand ) :
+        KSMathArray<5>( anOperand )
+    {
+    }
     KSTrajMagneticDerivative::~KSTrajMagneticDerivative()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajMagneticError.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajMagneticError.cxx
@@ -12,6 +12,11 @@ namespace Kassiopeia
     {
     }
 
+    KSTrajMagneticError::KSTrajMagneticError( const KSTrajMagneticError& anOperand ) :
+         KSMathArray< 5 >( anOperand )
+    {
+    }
+
     KSTrajMagneticError::~KSTrajMagneticError()
     {
     }

--- a/Kassiopeia/Trajectories/Source/KSTrajMagneticParticle.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajMagneticParticle.cxx
@@ -48,6 +48,35 @@ namespace Kassiopeia
             fGetElectricPotentialPtr( &KSTrajMagneticParticle::RecalculateElectricPotential )
     {
     }
+    KSTrajMagneticParticle::KSTrajMagneticParticle( const KSTrajMagneticParticle& aParticle ) :
+            KSMathArray<5>( aParticle ),
+            fTime( aParticle.fTime ),
+            fLength( aParticle.fLength ),
+            fPosition( aParticle.fPosition ),
+            fMomentum( aParticle.fMomentum ),
+            fVelocity( aParticle.fVelocity ),
+            fLorentzFactor( aParticle.fLorentzFactor ),
+            fKineticEnergy( aParticle.fKineticEnergy ),
+
+            fMagneticField( aParticle.fMagneticField ),
+            fElectricField( aParticle.fElectricField ),
+            fMagneticGradient( aParticle.fMagneticGradient ),
+            fElectricPotential( aParticle.fElectricPotential ),
+
+            fGuidingCenter( aParticle.fGuidingCenter ),
+            fLongMomentum( aParticle.fLongMomentum ),
+            fTransMomentum( aParticle.fTransMomentum ),
+            fLongVelocity( aParticle.fLongVelocity ),
+            fTransVelocity( aParticle.fTransVelocity ),
+            fCyclotronFrequency( aParticle.fCyclotronFrequency ),
+            fOrbitalMagneticMoment( aParticle.fOrbitalMagneticMoment ),
+
+            fGetMagneticFieldPtr( aParticle.fGetMagneticFieldPtr ),
+            fGetElectricFieldPtr( aParticle.fGetElectricFieldPtr ),
+            fGetMagneticGradientPtr( aParticle.fGetMagneticGradientPtr ),
+            fGetElectricPotentialPtr( aParticle.fGetElectricPotentialPtr )
+    {
+    }
     KSTrajMagneticParticle::~KSTrajMagneticParticle()
     {
     }


### PR DESCRIPTION
… present

In gcc-9 the warning -Wdeprecated-copy [1] is now enabled by -Wextra, and this
becomes an error when using -Werror as in CMakeLists.txt. This means that the
"implicit declaration of a copy constructor or copy assignment operator" is now
an error.

This commit adds copy constructors and assignment operators for those objects
where the other one is already explicitly declared. Copy constructors use the
parent copy constructor, assignment operators call the parent assignment operator.

In Kassiopeia/Trajectories/*/KSTraj*Particle classes the pointers to field functions
are copied in the initializer list instead of regenerated, e.g.:
```
fGetMagneticFieldPtr( aParticle.fGetMagneticFieldPtr )
```
Similarly the KSMathArray parent fields are copied for those classes.

[1] https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wdeprecated-copy