### PR TITLE
Avoid catch by value

### DIFF
--- a/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Core/include/KOpenCLBoundaryIntegralMatrix.hh
+++ b/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Core/include/KOpenCLBoundaryIntegralMatrix.hh
@@ -171,7 +171,7 @@ namespace KEMField
       devices.push_back( KOpenCLInterface::GetInstance()->GetDevice() );
       program.build(devices,GetOpenCLFlags().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<"There was an error compiling Boundary Integral kernels.  Here is the information from the OpenCL C++ API:"<<std::endl;

--- a/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Core/include/KOpenCLBoundaryIntegralSolutionVector.hh
+++ b/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Core/include/KOpenCLBoundaryIntegralSolutionVector.hh
@@ -226,7 +226,7 @@ namespace KEMField
       program.build(devices,
 		    options.str().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<"There was an error compiling the solution vector kernel.  Here is the information from the OpenCL C++ API:"<<std::endl;

--- a/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Core/include/KOpenCLBoundaryIntegralVector.hh
+++ b/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Core/include/KOpenCLBoundaryIntegralVector.hh
@@ -192,7 +192,7 @@ namespace KEMField
       program.build(devices,
 		    options.str().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<"There was an error compiling the kernels.  Here is the information from the OpenCL C++ API:"<<std::endl;

--- a/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Electrostatic/src/KOpenCLElectrostaticBoundaryIntegrator.cc
+++ b/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Electrostatic/src/KOpenCLElectrostaticBoundaryIntegrator.cc
@@ -112,7 +112,7 @@ namespace KEMField
       devices.push_back( KOpenCLInterface::GetInstance()->GetDevice() );
       program.build(devices,options.str().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::stringstream s;

--- a/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/ElectrostaticNumeric/src/KOpenCLElectrostaticNumericBoundaryIntegrator.cc
+++ b/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/ElectrostaticNumeric/src/KOpenCLElectrostaticNumericBoundaryIntegrator.cc
@@ -107,7 +107,7 @@ namespace KEMField
       devices.push_back( KOpenCLInterface::GetInstance()->GetDevice() );
       program.build(devices,options.str().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::stringstream s;

--- a/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/RWG/src/KOpenCLElectrostaticRWGBoundaryIntegrator.cc
+++ b/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/RWG/src/KOpenCLElectrostaticRWGBoundaryIntegrator.cc
@@ -106,7 +106,7 @@ namespace KEMField
       devices.push_back( KOpenCLInterface::GetInstance()->GetDevice() );
       program.build(devices,options.str().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::stringstream s;

--- a/KEMField/Source/Plugins/OpenCL/Core/include/KOpenCLInterface.hh
+++ b/KEMField/Source/Plugins/OpenCL/Core/include/KOpenCLInterface.hh
@@ -74,7 +74,7 @@
 #endif
 
 #ifdef USE_CL_ERROR_TRY_CATCH
-#define CL_ERROR_CATCH  catch (cl::Error error) \
+#define CL_ERROR_CATCH  catch (cl::Error &error) \
                         { \
                             std::cout<<"OpenCL Exception caught: "<<std::endl;\
                             std::cout<<__FILE__<<":"<<__LINE__<<std::endl; \

--- a/KEMField/Source/Plugins/OpenCL/Core/src/GenerateOpenCLHeader.cc
+++ b/KEMField/Source/Plugins/OpenCL/Core/src/GenerateOpenCLHeader.cc
@@ -250,7 +250,7 @@ int main()
   {
     program.build(devices, options.str().c_str());
   }
-  catch (cl::Error error)
+  catch (cl::Error &error)
   {
     std::cerr<<"There was an error compiling the kernels.  Here is the information from the OpenCL C++ API:"<<std::endl;
     std::cerr<<error.what()<<"("<<error.err()<<")"<<std::endl;

--- a/KEMField/Source/Plugins/OpenCL/Core/src/KOpenCLKernelBuilder.cc
+++ b/KEMField/Source/Plugins/OpenCL/Core/src/KOpenCLKernelBuilder.cc
@@ -36,7 +36,7 @@ cl::Kernel* KOpenCLKernelBuilder::BuildKernel(std::string SourceFileName, std::s
         devices.push_back( KOpenCLInterface::GetInstance()->GetDevice() );
         program.build(devices,options.str().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
         std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
         std::stringstream s;
@@ -75,7 +75,7 @@ cl::Kernel* KOpenCLKernelBuilder::BuildKernel(std::string SourceFileName, std::s
     {
         kernel = new cl::Kernel(program, KernelName.c_str(), &err_code);
     }
-    catch(cl::Error error)
+    catch(cl::Error &error)
     {
         std::cout<<"Kernel construction failed with error code: "<<error.what()<<": "<<error.err()<<std::endl;
         std::exit(1);

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Tree/include/KFMSparseReducedScalarMomentRemoteToLocalConverter_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Tree/include/KFMSparseReducedScalarMomentRemoteToLocalConverter_OpenCL.hh
@@ -326,7 +326,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
             fM2LCoeffBufferCL
             = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_ONLY, m2l_size*sizeof(CL_TYPE2));
             }
-            catch (cl::Error error)
+            catch (cl::Error &error)
             {
                 std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                 std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -348,7 +348,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
             this->fNormalizationCoeffBufferCL
             = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_ONLY, norm_size*sizeof(CL_TYPE2));
             }
-            catch (cl::Error error)
+            catch (cl::Error &error)
             {
                 std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                 std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -371,7 +371,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
             this->fWorkspaceBufferCL
             = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_WRITE, workspace_size*sizeof(CL_TYPE2));
             }
-            catch (cl::Error error)
+            catch (cl::Error &error)
             {
                 std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                 std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -388,7 +388,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
             fReversedIndexArrayBufferCL
             = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_ONLY, (this->fTotalSpatialSize)*sizeof(unsigned int));
             }
-            catch (cl::Error error)
+            catch (cl::Error &error)
             {
                 std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                 std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -442,7 +442,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
                 fSourceScaleFactorBufferCL
                 = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_ONLY, sf_size*sizeof(CL_TYPE));
                 }
-                catch (cl::Error error)
+                catch (cl::Error &error)
                 {
                     std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                     std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -453,7 +453,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
                 fTargetScaleFactorBufferCL
                 = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_ONLY, sf_size*sizeof(CL_TYPE));
                 }
-                catch (cl::Error error)
+                catch (cl::Error &error)
                 {
                     std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                     std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -484,7 +484,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
             fPrimaryLocalCoeffBufferCL
             = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_WRITE, primary_size*sizeof(CL_TYPE2));
             }
-            catch (cl::Error error)
+            catch (cl::Error &error)
             {
                 std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                 std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -500,7 +500,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
             fNodeIDListBufferCL
             = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_ONLY, (this->fTotalSpatialSize)*sizeof(unsigned int));
             }
-            catch (cl::Error error)
+            catch (cl::Error &error)
             {
                 std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                 std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -514,7 +514,7 @@ public KFMReducedScalarMomentRemoteToLocalConverter<ObjectTypeList, SourceScalar
             fBlockSetIDListBufferCL
             = new cl::Buffer(KOpenCLInterface::GetInstance()->GetContext(), CL_MEM_READ_ONLY, (this->fTotalSpatialSize)*sizeof(unsigned int));
             }
-            catch (cl::Error error)
+            catch (cl::Error &error)
             {
                 std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
                 std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;

--- a/KEMField/Source/Plugins/OpenCL/FieldSolvers/Integrating/include/KOpenCLElectrostaticIntegratingFieldSolver.hh
+++ b/KEMField/Source/Plugins/OpenCL/FieldSolvers/Integrating/include/KOpenCLElectrostaticIntegratingFieldSolver.hh
@@ -234,7 +234,7 @@ namespace KEMField
       devices.push_back(KOpenCLInterface::GetInstance()->GetDevice());
       program.build(devices,GetOpenCLFlags().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<"There was an error compiling the kernels.  Here is the information from the OpenCL C++ API:"<<std::endl;

--- a/KEMField/Source/Plugins/OpenCL/LinearAlgebra/include/KGaussSeidel_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/LinearAlgebra/include/KGaussSeidel_OpenCL.hh
@@ -141,7 +141,7 @@ namespace KEMField
       devices.push_back( KOpenCLInterface::GetInstance()->GetDevice() );
       program.build(devices,(dynamic_cast<const KOpenCLAction&>(fA)).GetOpenCLFlags().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<"There was an error compiling the kernels.  Here is the information from the OpenCL C++ API:"<<std::endl;
@@ -468,7 +468,7 @@ namespace KEMField
 				      // *fLocalRange);
 				      cl::NullRange);
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -518,7 +518,7 @@ namespace KEMField
 				      *fRangeOne,
 				      *fRangeOne);
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;

--- a/KEMField/Source/Plugins/OpenCL/LinearAlgebra/include/KRobinHood_MPI_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/LinearAlgebra/include/KRobinHood_MPI_OpenCL.hh
@@ -204,7 +204,7 @@ namespace KEMField
       devices.push_back( KOpenCLInterface::GetInstance()->GetDevice() );
       program.build(devices, options.str().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<"There was an error compiling the kernels.  Here is the information from the OpenCL C++ API:"<<std::endl;
       std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;

--- a/KEMField/Source/Plugins/OpenCL/LinearAlgebra/include/KRobinHood_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/LinearAlgebra/include/KRobinHood_OpenCL.hh
@@ -158,7 +158,7 @@ namespace KEMField
       devices.push_back( KOpenCLInterface::GetInstance()->GetDevice() );
       program.build(devices,options.str().c_str());
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<"There was an error compiling the kernels.  Here is the information from the OpenCL C++ API:"<<std::endl;
@@ -510,7 +510,7 @@ namespace KEMField
 				      // *fLocalRange);
 				      cl::NullRange);
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;
@@ -560,7 +560,7 @@ namespace KEMField
     				      *fGlobalSize,
     				      *fLocalRange);
     }
-    catch (cl::Error error)
+    catch (cl::Error &error)
     {
       std::cout<<__FILE__<<":"<<__LINE__<<std::endl;
       std::cout<<error.what()<<"("<<error.err()<<")"<<std::endl;


### PR DESCRIPTION
With gcc-8 catch by value is a warning enabled by -Wall, and turned into
an error by -Werror in CMakeLists.txt. This turns the catch by value
statements (in the OpenCL interface) into catch by reference.

Note: This does not solve all compiler issues in gcc-9 when compiling with USE_OpenCL=ON.