### PR TITLE
Avoid bashisms in shell scripts with /bin/sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,5 +152,6 @@ endif()
 install( EXPORT KasperTargets DESTINATION ${CMAKE_INSTALL_DIR} )
 
 configure_file( kasperenv.sh.in ${CMAKE_CURRENT_BINARY_DIR}/kasperenv.sh @ONLY )
+configure_file( kasper-krypton.bash.in ${CMAKE_CURRENT_BINARY_DIR}/kasper-krypton.bash @ONLY )
 configure_file( create_kasper_user_directory.sh.in ${CMAKE_CURRENT_BINARY_DIR}/create_kasper_user_directory.sh @ONLY )
-install( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/kasperenv.sh ${CMAKE_CURRENT_BINARY_DIR}/create_kasper_user_directory.sh DESTINATION ${BIN_INSTALL_DIR} )
+install( PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/kasperenv.sh ${CMAKE_CURRENT_BINARY_DIR}/kasper-krypton.bash ${CMAKE_CURRENT_BINARY_DIR}/create_kasper_user_directory.sh DESTINATION ${BIN_INSTALL_DIR} )

--- a/create_kasper_user_directory.sh.in
+++ b/create_kasper_user_directory.sh.in
@@ -18,12 +18,12 @@ cp -n -r $T_KASPER_INSTALL/log $T_KASPERSYS
 cp -n -r $T_KASPER_INSTALL/output $T_KASPERSYS
 cp -n -r $T_KASPER_INSTALL/scratch $T_KASPERSYS
 
-echo "#!/bin/sh" >> $T_KASPERSYS/bin/kasperenv.sh
-echo "source $T_KASPER_INSTALL/bin/kasperenv.sh $T_KASPERSYS" >> $T_KASPERSYS/bin/kasperenv.sh
+echo "#!/bin/sh" > $T_KASPERSYS/bin/kasperenv.sh
+echo ". $T_KASPER_INSTALL/bin/kasperenv.sh $T_KASPERSYS" >> $T_KASPERSYS/bin/kasperenv.sh
 
 echo "\033[32;1mKASPER user directory ${T_KASPERSYS} created\033[0m"
 echo "\033[32;1msource ${T_KASPERSYS}/bin/kasperenv.sh in your .bashrc/.zshrc to use it permanently\033[0m"
 
-source $T_KASPERSYS/bin/kasperenv.sh
+. $T_KASPERSYS/bin/kasperenv.sh
 
 return 0

--- a/kasper-krypton.bash.in
+++ b/kasper-krypton.bash.in
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+function _kafit_krypton_auto()
+{
+    local curr_arg;
+    curr_arg=${COMP_WORDS[COMP_CWORD]}
+    COMPREPLY=( $(compgen -W 'DrawData drawdata DrawResponse drawresponse DrawRP drawrp DrawMF drawmf Test test Fit fit DrawFitResult drawfitresult DrawResidual drawresidual FitSummary fitsummary --mode= --num= --ringselection=\" --fitrange=\" --batch= --auto= --average= --relative= --input= --output= true false uniform ring pixel' -- $curr_arg ) )
+}
+complete -o nospace -F  _kafit_krypton_auto  kafit-krypton
+

--- a/kasperenv.sh.in
+++ b/kasperenv.sh.in
@@ -57,21 +57,15 @@ fi
 export KEMFIELD_CACHE
 mkdir -p ${KEMFIELD_CACHE}
 
-export PATH=${KASPER_INSTALL_BIN}:${PATH//${OLD_PATH}/}
-export LD_LIBRARY_PATH=${KASPER_INSTALL_LIB}:${LD_LIBRARY_PATH//${OLD_LDLIBPATH}/}
-export PKG_CONFIG_PATH=${KASPER_INSTALL_LIB}/pkgconfig:${PKG_CONFIG_PATH//${OLD_PKGCFGPATH}/}
-export PYTHONPATH=${KASPER_INSTALL_LIB}/python:${PYTHONPATH//${OLD_PYTHONPATH}/}
-export CMAKE_PREFIX_PATH=${KASPER_INSTALL}:${CMAKE_PREFIX_PATH//${OLD_CMAKE_PREF}/}
+export PATH=${KASPER_INSTALL_BIN}:$(echo $PATH | sed 's/${OLD_PATH}//g')
+export LD_LIBRARY_PATH=${KASPER_INSTALL_LIB}:$(echo $LD_LIBRARY_PATH | sed 's/${OLD_LDLIBPATH}//g')
+export PKG_CONFIG_PATH=${KASPER_INSTALL_LIB}/pkgconfig:$(echo $PKG_CONFIG_PATH | sed 's/${OLD_PKGCFGPATH}//g')
+export PYTHONPATH=${KASPER_INSTALL_LIB}/python:$(echo $PYTHONPATH | sed 's/${OLD_PYTHONPATH}//g')
+export CMAKE_PREFIX_PATH=${KASPER_INSTALL}:$(echo $CMAKE_PREFIX_PATH | sed 's/${OLD_CMAKE_PREF}//g')
 
-echo -e "\033[32;1mKASPER config  directory set to ${KASPERSYS}\033[0m"
-echo -e "\033[32;1mKASPER install  directory set to ${KASPER_INSTALL}\033[0m"
+printf "\033[32;1mKASPER config  directory set to ${KASPERSYS}\033[0m\n"
+printf "\033[32;1mKASPER install  directory set to ${KASPER_INSTALL}\033[0m\n"
 
-function _kafit_krypton_auto()
-{
-    local curr_arg;
-    curr_arg=${COMP_WORDS[COMP_CWORD]}
-    COMPREPLY=( $(compgen -W 'DrawData drawdata DrawResponse drawresponse DrawRP drawrp DrawMF drawmf Test test Fit fit DrawFitResult drawfitresult DrawResidual drawresidual FitSummary fitsummary --mode= --num= --ringselection=\" --fitrange=\" --batch= --auto= --average= --relative= --input= --output= true false uniform ring pixel' -- $curr_arg ) );
-}
-[ ! -z "${BASH}" ] && complete -o nospace -F  _kafit_krypton_auto  kafit-krypton
+[ ! -z "${BASH}" ] && . ${KASPER_INSTALL_BIN}/kasper-krypton.bash
 
 return 0


### PR DESCRIPTION
This addresses (I hope) all issues in #10 https://github.com/KATRIN-Experiment/Kassiopeia/issues/10.

New file kasper-krypton.bash with bash-completion code which is
installed to ${BIN_INSTALL_DIR} and loaded if bash is used.