### PR TITLE
Respect the path attribute in the vtk_track_terminator_painter tag

### DIFF
--- a/Kassiopeia/Visualization/Source/KSVTKTrackTerminatorPainter.cxx
+++ b/Kassiopeia/Visualization/Source/KSVTKTrackTerminatorPainter.cxx
@@ -129,11 +129,25 @@ namespace Kassiopeia
 
             if( fOutFile.length() > 0 )
             {
-                tFile = string( OUTPUT_DEFAULT_DIR ) + string( "/" ) + fOutFile;
+                if( !fPath.empty() )
+                {
+                    tFile = string( fPath ) + string( "/" ) + fOutFile;
+                }
+                else
+                {
+                    tFile = string( OUTPUT_DEFAULT_DIR ) + string( "/" ) + fOutFile;
+                }
             }
             else
             {
-                tFile = string( OUTPUT_DEFAULT_DIR ) + string( "/" ) + GetName() + string( ".vtp" );
+                if( !fPath.empty() )
+                {
+                    tFile = string( fPath ) + string( "/" ) + GetName() + string( ".vtp" );
+                }
+                else
+                {
+                    tFile = string( OUTPUT_DEFAULT_DIR ) + string( "/" ) + GetName() + string( ".vtp" );
+                }
             }
 
             vismsg( eNormal ) << "vtk track terminator painter <" << GetName() << "> is writing <" << fData->GetNumberOfCells() << "> cells to file <" << tFile << ">" << eom;


### PR DESCRIPTION
Adding `path="[output_path]"` to the <vtk_track_terminator_painter>
tag would seem to suggest that `terminator_painter.vtp` should be
written to `[output_path]`, much like is done by `track_painter.vtp`.

This commit adds the same behavior for `track_painter.vtp` to the code
handling `terminator_painter.vtp` output path.