### PR TITLE
Add output path to kswrite_root and kswrite_vtk for DipoleTrapSimulation.xml

### DIFF
--- a/Kassiopeia/XML/Examples/AnalyticSimulation.xml
+++ b/Kassiopeia/XML/Examples/AnalyticSimulation.xml
@@ -5,28 +5,28 @@
     <file path="[log_path]" base="AnalyticSimulationLog.txt"/>
 
     <message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="debug" log="normal"/>
+    <message key="ks_object" terminal="debug" log="normal"/>
     <message key="ks_operator" terminal="debug" log="normal"/>
-	<message key="ks_field" terminal="debug" log="normal"/>
-	<message key="ks_geometry" terminal="debug" log="normal"/>
+    <message key="ks_field" terminal="debug" log="normal"/>
+    <message key="ks_geometry" terminal="debug" log="normal"/>
     <message key="ks_generator" terminal="debug" log="normal"/>
-	<message key="ks_trajectory" terminal="debug" log="normal"/>
-	<message key="ks_interaction" terminal="debug" log="normal"/>
+    <message key="ks_trajectory" terminal="debug" log="normal"/>
+    <message key="ks_interaction" terminal="debug" log="normal"/>
     <message key="ks_navigator" terminal="debug" log="normal"/>
-	<message key="ks_terminator" terminal="debug" log="normal"/>
-	<message key="ks_writer" terminal="debug" log="normal"/>
-	<message key="ks_main" terminal="debug" log="normal"/>
-	<message key="ks_run" terminal="debug" log="normal"/>
-	<message key="ks_event" terminal="debug" log="normal"/>
-	<message key="ks_track" terminal="debug" log="normal"/>
-	<message key="ks_step" terminal="debug" log="normal"/>
+    <message key="ks_terminator" terminal="debug" log="normal"/>
+    <message key="ks_writer" terminal="debug" log="normal"/>
+    <message key="ks_main" terminal="debug" log="normal"/>
+    <message key="ks_run" terminal="debug" log="normal"/>
+    <message key="ks_event" terminal="debug" log="normal"/>
+    <message key="ks_track" terminal="debug" log="normal"/>
+    <message key="ks_step" terminal="debug" log="normal"/>
 
 </messages>
 
@@ -65,7 +65,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_magnetic_constant
         name="field_magnetic_constant"
@@ -82,7 +82,7 @@
         radius="1.e-2"
     />
 
-	<!-- generators -->
+    <!-- generators -->
 
     <ksgen_generator_composite name="generator_fix">
         <energy_composite>
@@ -102,7 +102,7 @@
         </time_composite>
     </ksgen_generator_composite>
 
-	<!-- trajectories-->
+    <!-- trajectories-->
 
     <kstraj_trajectory_exact name="trajectory_exact">
         <integrator_rk8 name="integrator_rk8"/>
@@ -110,7 +110,7 @@
         <control_cyclotron name="control_cyclotron_1_16" fraction="{1. / 32.}"/>
     </kstraj_trajectory_exact>
 
-	<!-- space interactions -->
+    <!-- space interactions -->
 
     <ksint_scattering name="int_constant_scattering" split="false">
         <density_constant name="density_constant" temperature="300." pressure="3.e0"/>

--- a/Kassiopeia/XML/Examples/DipoleTrapMeshedSpaceSimulation.xml
+++ b/Kassiopeia/XML/Examples/DipoleTrapMeshedSpaceSimulation.xml
@@ -5,76 +5,76 @@
 
     <file path="[log_path]" base="DipoleTrapMeshedLog.txt"/>
 
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_file" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="normal" log="normal"/>
+    <message key="ks_object" terminal="normal" log="normal"/>
     <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
+    <message key="ks_field" terminal="normal" log="normal"/>
+    <message key="ks_geometry" terminal="normal" log="normal"/>
     <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="normal"/>
+    <message key="ks_trajectory" terminal="normal" log="normal"/>
+    <message key="ks_interaction" terminal="normal" log="normal"/>
     <message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
+    <message key="ks_terminator" terminal="normal" log="normal"/>
+    <message key="ks_writer" terminal="normal" log="normal"/>
+    <message key="ks_main" terminal="normal" log="normal"/>
+    <message key="ks_run" terminal="normal" log="normal"/>
+    <message key="ks_event" terminal="normal" log="normal"/>
+    <message key="ks_track" terminal="normal" log="normal"/>
+    <message key="ks_step" terminal="normal" log="normal"/>
 
 </messages>
 
 
 <geometry>
 
-	<!-- world -->
+    <!-- world -->
 
-	<cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
+    <cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
 
-	<!-- solenoid -->
+    <!-- solenoid -->
 
     <tag name="magnet_tag">
         <cylinder_tube_space
-        	name="solenoid_space"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r1="0.5e-2"
-        	r2="1.5e-2"
-        	radial_mesh_count="30"
+            name="solenoid_space"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r1="0.5e-2"
+            r2="1.5e-2"
+            radial_mesh_count="30"
         />
     </tag>
 
     <!-- ring -->
 
     <tag name="electrode_tag">
-    	<cylinder_surface
-    		name="ring_surface"
-    		z1="-2.0e-2"
-    		z2="2.0e-2"
-    		r="2.5e-1"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="ring_surface"
+            z1="-2.0e-2"
+            z2="2.0e-2"
+            r="2.5e-1"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="3."
             axial_mesh_count="128"
         />
     </tag>
 
-	<!-- guard surface -->
-	<!-- this surface is to keep particle from getting too close to the electrode -->
-	<!-- if they are too close the field calculation will fail -->
+    <!-- guard surface -->
+    <!-- this surface is to keep particle from getting too close to the electrode -->
+    <!-- if they are too close the field calculation will fail -->
     <tag name="guard_tag">
-    	<cylinder_surface
-    		name="guard_surface"
-    		z1="-0.5"
-    		z2="0.5"
-    		r="0.21"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="guard_surface"
+            z1="-0.5"
+            z2="0.5"
+            r="0.21"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="1."
             axial_mesh_count="128"
         />
@@ -84,12 +84,12 @@
     <!-- tube -->
 
     <tag name="electrode_tag">
-    	<cylinder_surface
-    		name="tube_surface"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r="0.5e-2"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="tube_surface"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r="0.5e-2"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="3."
             axial_mesh_count="128"
         />
@@ -106,12 +106,12 @@
         <disk_surface name="center_surface" radial_mesh_count="32" radial_mesh_power="1" axial_mesh_count="32" r="2.5e-1" z="0.0"/>
     </tag>
 
-	<!-- intermediate z-coordinate surfaces -->
-	<tag name="intermediate_z_tag">
+    <!-- intermediate z-coordinate surfaces -->
+    <tag name="intermediate_z_tag">
         <disk_surface name="intermediate_z_surface" radial_mesh_count="32" radial_mesh_power="1" axial_mesh_count="32" r="2.5e-1" z="0.0"/>
-	</tag>
+    </tag>
 
-	<!-- azimuthal surfaces intersection testing -->
+    <!-- azimuthal surfaces intersection testing -->
     <extruded_line_segment_surface name="azimuthal_surface" zmin="-0.5" zmax="0.5" extruded_mesh_count="64" extruded_mesh_power="1">
         <line_segment x1="0." y1="0." x2="0.5" y2="0.0" line_mesh_count="64" line_mesh_power="1"/>
     </extruded_line_segment_surface>
@@ -119,44 +119,44 @@
     <!-- assembly -->
 
     <space name="dipole_trap_assembly">
-    	<surface name="ring" node="ring_surface"/>
+        <surface name="ring" node="ring_surface"/>
         <surface name="center" node="center_surface"/>
-		<loop variable="i" start="0" end="10" step="1">
-		<surface name="intermediate_z[i]" node="intermediate_z_surface">
-    		<transformation displacement="0. 0. {-0.5 + [i]*(0.4/10.)}"/>
-		</surface>
-    	</loop>
-		<loop variable="i" start="10" end="20" step="1">
-		<surface name="intermediate_z[i]" node="intermediate_z_surface">
-    		<transformation displacement="0. 0. {0.1 + ([i]-10)*(0.4/10.)}"/>
-		</surface>
-    	</loop>
-		<loop variable="i" start="0" end="20" step="1">
-		<surface name="azimuthal[i]" node="azimuthal_surface">
-    		<transformation rotation_euler="0. 0. {[i]*(360.0/20.)}"/>
-		</surface>
-    	</loop>
-    	<space name="downstream_solenoid" node="solenoid_space">
-    		<transformation displacement="0. 0. -0.5"/>
-    	</space>
-    	<surface name="downstream_tube" node="tube_surface">
-    		<transformation displacement="0. 0. -0.5"/>
-    	</surface>
-    	<surface name="upstream_target" node="target_surface">
-    		<transformation displacement="0. 0. -0.48"/>
-    	</surface>
-    	<space name="upstream_solenoid" node="solenoid_space">
-    		<transformation displacement="0. 0. 0.5"/>
-    	</space>
-    	<surface name="upstream_tube" node="tube_surface">
-    		<transformation displacement="0. 0. 0.5"/>
-    	</surface>
-    	<surface name="downstream_target" node="target_surface">
-    		<transformation displacement="0. 0. 0.48"/>
-    	</surface>
-		<surface name="guard" node="guard_surface">
-			<transformation displacement="0. 0. 0.0"/>
-		</surface>
+        <loop variable="i" start="0" end="10" step="1">
+        <surface name="intermediate_z[i]" node="intermediate_z_surface">
+            <transformation displacement="0. 0. {-0.5 + [i]*(0.4/10.)}"/>
+        </surface>
+        </loop>
+        <loop variable="i" start="10" end="20" step="1">
+        <surface name="intermediate_z[i]" node="intermediate_z_surface">
+            <transformation displacement="0. 0. {0.1 + ([i]-10)*(0.4/10.)}"/>
+        </surface>
+        </loop>
+        <loop variable="i" start="0" end="20" step="1">
+        <surface name="azimuthal[i]" node="azimuthal_surface">
+            <transformation rotation_euler="0. 0. {[i]*(360.0/20.)}"/>
+        </surface>
+        </loop>
+        <space name="downstream_solenoid" node="solenoid_space">
+            <transformation displacement="0. 0. -0.5"/>
+        </space>
+        <surface name="downstream_tube" node="tube_surface">
+            <transformation displacement="0. 0. -0.5"/>
+        </surface>
+        <surface name="upstream_target" node="target_surface">
+            <transformation displacement="0. 0. -0.48"/>
+        </surface>
+        <space name="upstream_solenoid" node="solenoid_space">
+            <transformation displacement="0. 0. 0.5"/>
+        </space>
+        <surface name="upstream_tube" node="tube_surface">
+            <transformation displacement="0. 0. 0.5"/>
+        </surface>
+        <surface name="downstream_target" node="target_surface">
+            <transformation displacement="0. 0. 0.48"/>
+        </surface>
+        <surface name="guard" node="guard_surface">
+            <transformation displacement="0. 0. 0.0"/>
+        </surface>
     </space>
 
     <space name="world" node="world_space">
@@ -188,7 +188,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_electromagnet
         name="field_electromagnet"
@@ -245,13 +245,13 @@
     </ksfield_electrostatic>
 
     <ksfield_electric_constant
-    	name="field_constant"
-    	field="0. 0. 0."
-	/>
+        name="field_constant"
+        field="0. 0. 0."
+    />
 
-	<!-- generators -->
+    <!-- generators -->
 
-	<ksgen_generator_composite name="generator_uniform" pid="11">
+    <ksgen_generator_composite name="generator_uniform" pid="11">
         <energy_composite>
             <energy_fix value="1."/>
         </energy_composite>
@@ -271,10 +271,10 @@
 
     <!-- trajectories-->
 
-	<!-- specify the name of trajectory type to be used for tracking -->
-	<define name="trajectory_name" value="trajectory_adiabatic"/>
+    <!-- specify the name of trajectory type to be used for tracking -->
+    <define name="trajectory_name" value="trajectory_adiabatic"/>
 
-	<!-- exact trajectory -->
+    <!-- exact trajectory -->
     <kstraj_trajectory_exact name="trajectory_exact" piecewise_tolerance="1e-12" max_segments="64">
         <interpolator_crk name="interpolator_crk"/>
         <integrator_rkdp853 name="integrator_rkdp853"/>
@@ -401,16 +401,16 @@
         <geo_surface name="surface_electrode_ring" surfaces="world/dipole_trap/ring">
             <command parent="root_terminator" field="add_terminator" child="term_ring"/>
         </geo_surface>
-		<loop variable="i" start="0" end="20" step="1">
+        <loop variable="i" start="0" end="20" step="1">
          <geo_surface name="surface_intermediate_z[i]" surfaces="world/dipole_trap/intermediate_z[i]"/>
-    	</loop>
-		<loop variable="i" start="0" end="20" step="1">
+        </loop>
+        <loop variable="i" start="0" end="20" step="1">
          <geo_surface name="surface_azimuthal[i]" surfaces="world/dipole_trap/azimuthal[i]"/>
-    	</loop>
+        </loop>
     </ksgeo_space>
 
-	<!-- meshed space navigator must be specified after structure so it can construct the octree -->
-	<!-- Note: if you see multiple intersections detected in the same place, you may need to increase your tolerances -->
+    <!-- meshed space navigator must be specified after structure so it can construct the octree -->
+    <!-- Note: if you see multiple intersections detected in the same place, you may need to increase your tolerances -->
     <ksnav_meshed_space
         name="nav_meshed_space"
         octree_file="dipole_octree.kbd"

--- a/Kassiopeia/XML/Examples/DipoleTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/DipoleTrapSimulation.xml
@@ -4,60 +4,60 @@
 <messages>
     <file path="[log_path]" base="DipoleTrapLog.txt"/>
 
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_file" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="normal" log="normal"/>
+    <message key="ks_object" terminal="normal" log="normal"/>
     <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
+    <message key="ks_field" terminal="normal" log="normal"/>
+    <message key="ks_geometry" terminal="normal" log="normal"/>
     <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="normal"/>
+    <message key="ks_trajectory" terminal="normal" log="normal"/>
+    <message key="ks_interaction" terminal="normal" log="normal"/>
     <message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
+    <message key="ks_terminator" terminal="normal" log="normal"/>
+    <message key="ks_writer" terminal="normal" log="normal"/>
+    <message key="ks_main" terminal="normal" log="normal"/>
+    <message key="ks_run" terminal="normal" log="normal"/>
+    <message key="ks_event" terminal="normal" log="normal"/>
+    <message key="ks_track" terminal="normal" log="normal"/>
+    <message key="ks_step" terminal="normal" log="normal"/>
 
 </messages>
 
 <geometry>
 
-	<!-- world -->
+    <!-- world -->
 
-	<cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
+    <cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
 
-	<!-- solenoid -->
+    <!-- solenoid -->
 
     <tag name="magnet_tag">
         <cylinder_tube_space
-        	name="solenoid_space"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r1="0.5e-2"
-        	r2="1.5e-2"
-        	radial_mesh_count="30"
+            name="solenoid_space"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r1="0.5e-2"
+            r2="1.5e-2"
+            radial_mesh_count="30"
         />
     </tag>
 
     <!-- ring -->
 
     <tag name="electrode_tag">
-    	<cylinder_surface
-    		name="ring_surface"
-    		z1="-2.0e-2"
-    		z2="2.0e-2"
-    		r="2.5e-1"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="ring_surface"
+            z1="-2.0e-2"
+            z2="2.0e-2"
+            r="2.5e-1"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="3."
             axial_mesh_count="128"
         />
@@ -66,12 +66,12 @@
     <!-- tube -->
 
     <tag name="electrode_tag">
-    	<cylinder_surface
-    		name="tube_surface"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r="0.5e-2"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="tube_surface"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r="0.5e-2"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="3."
             axial_mesh_count="128"
         />
@@ -92,26 +92,26 @@
     <!-- assembly -->
 
     <space name="dipole_trap_assembly">
-    	<surface name="ring" node="ring_surface"/>
+        <surface name="ring" node="ring_surface"/>
         <surface name="center" node="center_surface"/>
-    	<space name="downstream_solenoid" node="solenoid_space">
-    		<transformation displacement="0. 0. -0.5"/>
-    	</space>
-    	<surface name="downstream_tube" node="tube_surface">
-    		<transformation displacement="0. 0. -0.5"/>
-    	</surface>
-    	<surface name="upstream_target" node="target_surface">
-    		<transformation displacement="0. 0. -0.48"/>
-    	</surface>
-    	<space name="upstream_solenoid" node="solenoid_space">
-    		<transformation displacement="0. 0. 0.5"/>
-    	</space>
-    	<surface name="upstream_tube" node="tube_surface">
-    		<transformation displacement="0. 0. 0.5"/>
-    	</surface>
-    	<surface name="downstream_target" node="target_surface">
-    		<transformation displacement="0. 0. 0.48"/>
-    	</surface>
+        <space name="downstream_solenoid" node="solenoid_space">
+            <transformation displacement="0. 0. -0.5"/>
+        </space>
+        <surface name="downstream_tube" node="tube_surface">
+            <transformation displacement="0. 0. -0.5"/>
+        </surface>
+        <surface name="upstream_target" node="target_surface">
+            <transformation displacement="0. 0. -0.48"/>
+        </surface>
+        <space name="upstream_solenoid" node="solenoid_space">
+            <transformation displacement="0. 0. 0.5"/>
+        </space>
+        <surface name="upstream_tube" node="tube_surface">
+            <transformation displacement="0. 0. 0.5"/>
+        </surface>
+        <surface name="downstream_target" node="target_surface">
+            <transformation displacement="0. 0. 0.48"/>
+        </surface>
     </space>
 
     <space name="world" node="world_space">
@@ -143,7 +143,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_electromagnet
         name="field_electromagnet"
@@ -201,13 +201,13 @@
     </ksfield_electrostatic>
 
     <ksfield_electric_constant
-    	name="field_constant"
-    	field="0. 0. 0."
-	/>
+        name="field_constant"
+        field="0. 0. 0."
+    />
 
-	<!-- generators -->
+    <!-- generators -->
 
-	<ksgen_generator_composite name="generator_uniform" pid="11">
+    <ksgen_generator_composite name="generator_uniform" pid="11">
         <energy_composite>
             <energy_fix value="1."/>
         </energy_composite>

--- a/Kassiopeia/XML/Examples/DipoleTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/DipoleTrapSimulation.xml
@@ -252,7 +252,7 @@
 
     <!-- writers -->
 
-    <kswrite_root name="write_root" base="DipoleTrapSimulation.root"/>
+    <kswrite_root name="write_root" path="[output_path]" base="DipoleTrapSimulation.root"/>
 
     <!-- output -->
 

--- a/Kassiopeia/XML/Examples/PhotoMultiplierTubeSimulation.xml
+++ b/Kassiopeia/XML/Examples/PhotoMultiplierTubeSimulation.xml
@@ -3,30 +3,30 @@
 
 <messages>
 
-	<file path="[log_path]" base="PhotoMultiplierTubeLog.txt"/>
+    <file path="[log_path]" base="PhotoMultiplierTubeLog.txt"/>
 
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_file" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="normal" log="normal"/>
+    <message key="ks_object" terminal="normal" log="normal"/>
     <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="debug"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
+    <message key="ks_field" terminal="normal" log="normal"/>
+    <message key="ks_generator" terminal="normal" log="normal"/>
+    <message key="ks_trajectory" terminal="normal" log="normal"/>
+    <message key="ks_interaction" terminal="normal" log="debug"/>
+    <message key="ks_terminator" terminal="normal" log="normal"/>
+    <message key="ks_writer" terminal="normal" log="normal"/>
+    <message key="ks_navigator" terminal="normal" log="normal"/>
+    <message key="ks_main" terminal="normal" log="normal"/>
+    <message key="ks_run" terminal="normal" log="normal"/>
+    <message key="ks_event" terminal="normal" log="normal"/>
+    <message key="ks_track" terminal="normal" log="normal"/>
+    <message key="ks_step" terminal="normal" log="normal"/>
 
 </messages>
 
@@ -62,16 +62,16 @@
     <tag name="electrode_tag" name="focusing_electrode0_tag">
         <beam_surface name="focusing_electrode0_surface">
           <beam longitudinal_mesh_count="20" axial_mesh_count="20">
-    	<define name="poly" value="120"/>
-    	<define name="fe0_r" value="{0.9*[radius]}"/>
-    	<define name="z_start_max" value="1.7e-2"/>
-    	<define name="z_start_min" value="1.2e-2"/>
-    	<define name="z_end_max" value="2.5e-2"/>
-    	<define name="z_end_min" value="2.5e-2"/>
-    	<loop variable="i" start="0" end="[poly]" step="1">
-    	  <start_line x1="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{([z_start_max]+[z_start_min])*.5 + ([z_start_max]-[z_start_min])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{([z_start_max]+[z_start_min])*.5 + ([z_start_max]-[z_start_min])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}"/>
-    	  <end_line x1="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{([z_end_max]+[z_end_min])*.5 + ([z_end_max]-[z_end_min])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{([z_end_max]+[z_end_min])*.5 + ([z_end_max]-[z_end_min])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}"/>
-    	</loop>
+        <define name="poly" value="120"/>
+        <define name="fe0_r" value="{0.9*[radius]}"/>
+        <define name="z_start_max" value="1.7e-2"/>
+        <define name="z_start_min" value="1.2e-2"/>
+        <define name="z_end_max" value="2.5e-2"/>
+        <define name="z_end_min" value="2.5e-2"/>
+        <loop variable="i" start="0" end="[poly]" step="1">
+          <start_line x1="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{([z_start_max]+[z_start_min])*.5 + ([z_start_max]-[z_start_min])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{([z_start_max]+[z_start_min])*.5 + ([z_start_max]-[z_start_min])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}"/>
+          <end_line x1="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{([z_end_max]+[z_end_min])*.5 + ([z_end_max]-[z_end_min])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{([z_end_max]+[z_end_min])*.5 + ([z_end_max]-[z_end_min])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}"/>
+        </loop>
             </beam>
         </beam_surface>
     </tag>
@@ -79,14 +79,14 @@
     <tag name="electrode_tag" name="focusing_electrode1_tag">
         <beam_surface name="focusing_electrode1_surface">
           <beam longitudinal_mesh_count="20" axial_mesh_count="20">
-    	<define name="fe1_router" value="{0.9*[radius]}"/>
-    	<define name="fe1_rinner" value="{0.5*[radius]}"/>
-    	<define name="x_inner" value="{0.17*[radius]}"/>
-    	<define name="y_inner" value="0"/>
-    	<loop variable="i" start="0" end="[poly]" step="1">
-    	  <start_line x1="{[fe1_router]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe1_router]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="0" x2="{[fe1_router]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe1_router]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="0"/>
-    	  <end_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="0" x2="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="0"/>
-    	</loop>
+        <define name="fe1_router" value="{0.9*[radius]}"/>
+        <define name="fe1_rinner" value="{0.5*[radius]}"/>
+        <define name="x_inner" value="{0.17*[radius]}"/>
+        <define name="y_inner" value="0"/>
+        <loop variable="i" start="0" end="[poly]" step="1">
+          <start_line x1="{[fe1_router]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe1_router]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="0" x2="{[fe1_router]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe1_router]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="0"/>
+          <end_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="0" x2="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="0"/>
+        </loop>
             </beam>
         </beam_surface>
     </tag>
@@ -94,14 +94,14 @@
     <tag name="electrode_tag" name="focusing_electrode2_tag">
         <beam_surface name="focusing_electrode2_surface">
         <beam longitudinal_mesh_count="20" axial_mesh_count="20">
-        	<define name="z2_start" value="2.5e-2"/>
-        	<define name="z2_start_del" value="0.0"/>
-        	<define name="z2_end" value="2.3e-2"/>
-        	<define name="z2_end_del" value="0.19e-2"/>
-        	<loop variable="i" start="0" end="[poly]" step="1">
+            <define name="z2_start" value="2.5e-2"/>
+            <define name="z2_start_del" value="0.0"/>
+            <define name="z2_end" value="2.3e-2"/>
+            <define name="z2_end_del" value="0.19e-2"/>
+            <loop variable="i" start="0" end="[poly]" step="1">
              <start_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{ [z2_start] + ([z2_start_del])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe1_rinner]*TMath::Cos( 2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{ [z2_start] + ([z2_start_del])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly]) /[poly] ) }"/>
-        	  <end_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{ [z2_end] + ([z2_end_del])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{ [z2_end] + ([z2_end_del])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly] )}"/>
-        	</loop>
+              <end_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{ [z2_end] + ([z2_end_del])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{ [z2_end] + ([z2_end_del])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly] )}"/>
+            </loop>
         </beam>
         </beam_surface>
     </tag>
@@ -267,7 +267,7 @@
 
     <space name="world" node="world_space">
         <space name="photomultiplier_tube" tree="photomultiplier_tube_assembly"/>
-    	<surface name="world_boundary" node="world_surface"/>
+        <surface name="world_boundary" node="world_surface"/>
     </space>
 
 </geometry>
@@ -275,7 +275,7 @@
 
 <kassiopeia>
 
-	<!-- fields -->
+    <!-- fields -->
 
     <ksfield_electrostatic
         name="kemfield_e"
@@ -358,7 +358,7 @@
     </ksfield_electrostatic>
 
 
-    <!--	 generators -->
+    <!--     generators -->
 
     <ksgen_generator_composite name="photoelectron_single">
         <energy_composite>
@@ -379,7 +379,7 @@
     </ksgen_generator_composite>
 
 
-	<!-- trajectories-->
+    <!-- trajectories-->
 
 
     <kstraj_trajectory_exact name="trajectory_exact">

--- a/Kassiopeia/XML/Examples/ToricTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/ToricTrapSimulation.xml
@@ -6,48 +6,48 @@
 
     <file path="[log_path]" base="ToricTrapLog.txt"/>
 
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_file" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="normal" log="normal"/>
+    <message key="ks_object" terminal="normal" log="normal"/>
     <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
+    <message key="ks_field" terminal="normal" log="normal"/>
+    <message key="ks_geometry" terminal="normal" log="normal"/>
     <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="debug" log="normal"/>
-	<message key="ks_interaction" terminal="debug" log="normal"/>
+    <message key="ks_trajectory" terminal="debug" log="normal"/>
+    <message key="ks_interaction" terminal="debug" log="normal"/>
     <message key="ks_navigator" terminal="debug" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="debug" log="normal"/>
+    <message key="ks_terminator" terminal="normal" log="normal"/>
+    <message key="ks_writer" terminal="normal" log="normal"/>
+    <message key="ks_main" terminal="normal" log="normal"/>
+    <message key="ks_run" terminal="normal" log="normal"/>
+    <message key="ks_event" terminal="normal" log="normal"/>
+    <message key="ks_track" terminal="normal" log="normal"/>
+    <message key="ks_step" terminal="debug" log="normal"/>
 
 </messages>
 
 <geometry>
 
-	<!-- world -->
+    <!-- world -->
 
-	<cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
+    <cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
 
-	<!-- solenoid -->
+    <!-- solenoid -->
 
     <tag name="magnet_tag">
         <cylinder_tube_space
-        	name="solenoid_space"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r1="0.5e-2"
-        	r2="1.5e-2"
-        	radial_mesh_count="30"
+            name="solenoid_space"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r1="0.5e-2"
+            r2="1.5e-2"
+            radial_mesh_count="30"
         />
     </tag>
 
@@ -71,10 +71,10 @@
     <!-- assembly -->
 
     <space name="toric_trap_assembly">
-    	<space name="east_solenoid" node="solenoid_space">
-    		<transformation rotation_axis_angle="90. 90. 0."/>
+        <space name="east_solenoid" node="solenoid_space">
+            <transformation rotation_axis_angle="90. 90. 0."/>
             <transformation displacement="5.0e-2 0. 0."/>
-    	</space>
+        </space>
         <space name="northeast_solenoid" node="solenoid_space">
             <transformation rotation_axis_angle="90. 90. 45."/>
             <transformation displacement="3.53553e-2 3.53553e-2 0."/>
@@ -149,7 +149,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_electromagnet
         name="field_electromagnet"
@@ -208,13 +208,13 @@
     -->
 
     <ksfield_electric_constant
-    	name="field_constant"
-    	field="0. 0. 0."
-	/>
+        name="field_constant"
+        field="0. 0. 0."
+    />
 
-	<!-- generators -->
+    <!-- generators -->
 
-	<ksgen_generator_composite name="generator_fix" pid="11">
+    <ksgen_generator_composite name="generator_fix" pid="11">
         <energy_composite>
             <energy_fix value="10."/>
         </energy_composite>
@@ -242,7 +242,7 @@
         <control_time name="control_time" time="5.e-9"/>
     </kstraj_trajectory_exact>
 
-	<!-- space interactions -->
+    <!-- space interactions -->
 
     <ksint_scattering name="int_scattering">
         <density_constant temperature="300." pressure="3.e0"/>

--- a/Kassiopeia/XML/Examples/VTK/AnalyticSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/AnalyticSimulation.xml
@@ -255,6 +255,7 @@
 >
     <vtk_geometry_painter 
         name="geometry_painter"
+        path="[output_path]"
         spaces="world/cell"
         surfaces="world/cell/target"
     />

--- a/Kassiopeia/XML/Examples/VTK/AnalyticSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/AnalyticSimulation.xml
@@ -3,30 +3,30 @@
 <messages>
 
     <file path="[log_path]" base="AnalyticSimulationLog.txt"/>
-	
+    
     <message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="debug" log="normal"/>
+    <message key="ks_object" terminal="debug" log="normal"/>
     <message key="ks_operator" terminal="debug" log="normal"/>
-	<message key="ks_field" terminal="debug" log="normal"/>
-	<message key="ks_geometry" terminal="debug" log="normal"/>
+    <message key="ks_field" terminal="debug" log="normal"/>
+    <message key="ks_geometry" terminal="debug" log="normal"/>
     <message key="ks_generator" terminal="debug" log="normal"/>
-	<message key="ks_trajectory" terminal="debug" log="normal"/>
-	<message key="ks_interaction" terminal="debug" log="normal"/>
+    <message key="ks_trajectory" terminal="debug" log="normal"/>
+    <message key="ks_interaction" terminal="debug" log="normal"/>
     <message key="ks_navigator" terminal="debug" log="normal"/>
-	<message key="ks_terminator" terminal="debug" log="normal"/>
-	<message key="ks_writer" terminal="debug" log="normal"/>
-	<message key="ks_main" terminal="debug" log="normal"/>
-	<message key="ks_run" terminal="debug" log="normal"/>
-	<message key="ks_event" terminal="debug" log="normal"/>
-	<message key="ks_track" terminal="debug" log="normal"/>
-	<message key="ks_step" terminal="debug" log="normal"/>
+    <message key="ks_terminator" terminal="debug" log="normal"/>
+    <message key="ks_writer" terminal="debug" log="normal"/>
+    <message key="ks_main" terminal="debug" log="normal"/>
+    <message key="ks_run" terminal="debug" log="normal"/>
+    <message key="ks_event" terminal="debug" log="normal"/>
+    <message key="ks_track" terminal="debug" log="normal"/>
+    <message key="ks_step" terminal="debug" log="normal"/>
 
 </messages>
 
@@ -65,7 +65,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_magnetic_constant
         name="field_magnetic_constant"
@@ -82,7 +82,7 @@
         radius="1.e-2"
     />
 
-	<!-- generators -->
+    <!-- generators -->
 
     <ksgen_generator_composite name="generator_fix">
         <energy_composite>
@@ -102,7 +102,7 @@
         </time_composite>
     </ksgen_generator_composite>    
 
-	<!-- trajectories-->
+    <!-- trajectories-->
 
     <kstraj_trajectory_exact name="trajectory_exact">
         <integrator_rk8 name="integrator_rk8"/>
@@ -110,7 +110,7 @@
         <control_cyclotron name="control_cyclotron_1_16" fraction="{1. / 32.}"/>
     </kstraj_trajectory_exact>
 
-	<!-- space interactions -->
+    <!-- space interactions -->
     
     <ksint_scattering name="int_constant_scattering" split="false">
         <density_constant name="density_constant" temperature="300." pressure="3.e0"/>  

--- a/Kassiopeia/XML/Examples/VTK/DipoleTrapMeshedSpaceSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/DipoleTrapMeshedSpaceSimulation.xml
@@ -5,76 +5,76 @@
 
     <file path="[log_path]" base="DipoleTrapMeshedLog.txt"/>
 
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_file" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="normal" log="normal"/>
+    <message key="ks_object" terminal="normal" log="normal"/>
     <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
+    <message key="ks_field" terminal="normal" log="normal"/>
+    <message key="ks_geometry" terminal="normal" log="normal"/>
     <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="normal"/>
+    <message key="ks_trajectory" terminal="normal" log="normal"/>
+    <message key="ks_interaction" terminal="normal" log="normal"/>
     <message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
+    <message key="ks_terminator" terminal="normal" log="normal"/>
+    <message key="ks_writer" terminal="normal" log="normal"/>
+    <message key="ks_main" terminal="normal" log="normal"/>
+    <message key="ks_run" terminal="normal" log="normal"/>
+    <message key="ks_event" terminal="normal" log="normal"/>
+    <message key="ks_track" terminal="normal" log="normal"/>
+    <message key="ks_step" terminal="normal" log="normal"/>
 
 </messages>
 
 
 <geometry>
 
-	<!-- world -->
+    <!-- world -->
 
-	<cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
+    <cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
 
-	<!-- solenoid -->
+    <!-- solenoid -->
 
     <tag name="magnet_tag">
         <cylinder_tube_space
-        	name="solenoid_space"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r1="0.5e-2"
-        	r2="1.5e-2"
-        	radial_mesh_count="30"
+            name="solenoid_space"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r1="0.5e-2"
+            r2="1.5e-2"
+            radial_mesh_count="30"
         />
     </tag>
 
     <!-- ring -->
 
     <tag name="electrode_tag">
-    	<cylinder_surface
-    		name="ring_surface"
-    		z1="-2.0e-2"
-    		z2="2.0e-2"
-    		r="2.5e-1"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="ring_surface"
+            z1="-2.0e-2"
+            z2="2.0e-2"
+            r="2.5e-1"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="3."
             axial_mesh_count="128"
         />
     </tag>
 
-	<!-- guard surface -->
-	<!-- this surface is to keep particle from getting too close to the electrode -->
-	<!-- if they are too close the field calculation will fail -->
+    <!-- guard surface -->
+    <!-- this surface is to keep particle from getting too close to the electrode -->
+    <!-- if they are too close the field calculation will fail -->
     <tag name="guard_tag">
-    	<cylinder_surface
-    		name="guard_surface"
-    		z1="-0.5"
-    		z2="0.5"
-    		r="0.21"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="guard_surface"
+            z1="-0.5"
+            z2="0.5"
+            r="0.21"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="1."
             axial_mesh_count="128"
         />
@@ -84,12 +84,12 @@
     <!-- tube -->
 
     <tag name="electrode_tag">
-    	<cylinder_surface
-    		name="tube_surface"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r="0.5e-2"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="tube_surface"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r="0.5e-2"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="3."
             axial_mesh_count="128"
         />
@@ -106,12 +106,12 @@
         <disk_surface name="center_surface" radial_mesh_count="32" radial_mesh_power="1" axial_mesh_count="32" r="2.5e-1" z="0.0"/>
     </tag>
 
-	<!-- intermediate z-coordinate surfaces -->
-	<tag name="intermediate_z_tag">
+    <!-- intermediate z-coordinate surfaces -->
+    <tag name="intermediate_z_tag">
         <disk_surface name="intermediate_z_surface" radial_mesh_count="32" radial_mesh_power="1" axial_mesh_count="32" r="2.5e-1" z="0.0"/>
-	</tag>
+    </tag>
 
-	<!-- azimuthal surfaces intersection testing -->
+    <!-- azimuthal surfaces intersection testing -->
     <extruded_line_segment_surface name="azimuthal_surface" zmin="-0.5" zmax="0.5" extruded_mesh_count="64" extruded_mesh_power="1">
         <line_segment x1="0." y1="0." x2="0.5" y2="0.0" line_mesh_count="64" line_mesh_power="1"/>
     </extruded_line_segment_surface>
@@ -119,44 +119,44 @@
     <!-- assembly -->
 
     <space name="dipole_trap_assembly">
-    	<surface name="ring" node="ring_surface"/>
+        <surface name="ring" node="ring_surface"/>
         <surface name="center" node="center_surface"/>
-		<loop variable="i" start="0" end="10" step="1">
-		<surface name="intermediate_z[i]" node="intermediate_z_surface">
-    		<transformation displacement="0. 0. {-0.5 + [i]*(0.4/10.)}"/>
-		</surface>
-    	</loop>
-		<loop variable="i" start="10" end="20" step="1">
-		<surface name="intermediate_z[i]" node="intermediate_z_surface">
-    		<transformation displacement="0. 0. {0.1 + ([i]-10)*(0.4/10.)}"/>
-		</surface>
-    	</loop>
-		<loop variable="i" start="0" end="20" step="1">
-		<surface name="azimuthal[i]" node="azimuthal_surface">
-    		<transformation rotation_euler="0. 0. {[i]*(360.0/20.)}"/>
-		</surface>
-    	</loop>
-    	<space name="downstream_solenoid" node="solenoid_space">
-    		<transformation displacement="0. 0. -0.5"/>
-    	</space>
-    	<surface name="downstream_tube" node="tube_surface">
-    		<transformation displacement="0. 0. -0.5"/>
-    	</surface>
-    	<surface name="upstream_target" node="target_surface">
-    		<transformation displacement="0. 0. -0.48"/>
-    	</surface>
-    	<space name="upstream_solenoid" node="solenoid_space">
-    		<transformation displacement="0. 0. 0.5"/>
-    	</space>
-    	<surface name="upstream_tube" node="tube_surface">
-    		<transformation displacement="0. 0. 0.5"/>
-    	</surface>
-    	<surface name="downstream_target" node="target_surface">
-    		<transformation displacement="0. 0. 0.48"/>
-    	</surface>
-		<surface name="guard" node="guard_surface">
-			<transformation displacement="0. 0. 0.0"/>
-		</surface>
+        <loop variable="i" start="0" end="10" step="1">
+        <surface name="intermediate_z[i]" node="intermediate_z_surface">
+            <transformation displacement="0. 0. {-0.5 + [i]*(0.4/10.)}"/>
+        </surface>
+        </loop>
+        <loop variable="i" start="10" end="20" step="1">
+        <surface name="intermediate_z[i]" node="intermediate_z_surface">
+            <transformation displacement="0. 0. {0.1 + ([i]-10)*(0.4/10.)}"/>
+        </surface>
+        </loop>
+        <loop variable="i" start="0" end="20" step="1">
+        <surface name="azimuthal[i]" node="azimuthal_surface">
+            <transformation rotation_euler="0. 0. {[i]*(360.0/20.)}"/>
+        </surface>
+        </loop>
+        <space name="downstream_solenoid" node="solenoid_space">
+            <transformation displacement="0. 0. -0.5"/>
+        </space>
+        <surface name="downstream_tube" node="tube_surface">
+            <transformation displacement="0. 0. -0.5"/>
+        </surface>
+        <surface name="upstream_target" node="target_surface">
+            <transformation displacement="0. 0. -0.48"/>
+        </surface>
+        <space name="upstream_solenoid" node="solenoid_space">
+            <transformation displacement="0. 0. 0.5"/>
+        </space>
+        <surface name="upstream_tube" node="tube_surface">
+            <transformation displacement="0. 0. 0.5"/>
+        </surface>
+        <surface name="downstream_target" node="target_surface">
+            <transformation displacement="0. 0. 0.48"/>
+        </surface>
+        <surface name="guard" node="guard_surface">
+            <transformation displacement="0. 0. 0.0"/>
+        </surface>
     </space>
 
     <space name="world" node="world_space">
@@ -188,7 +188,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_electromagnet
         name="field_electromagnet"
@@ -246,13 +246,13 @@
     </ksfield_electrostatic>
 
     <ksfield_electric_constant
-    	name="field_constant"
-    	field="0. 0. 0."
-	/>
+        name="field_constant"
+        field="0. 0. 0."
+    />
 
-	<!-- generators -->
+    <!-- generators -->
 
-	<ksgen_generator_composite name="generator_uniform" pid="11">
+    <ksgen_generator_composite name="generator_uniform" pid="11">
         <energy_composite>
             <energy_fix value="1."/>
         </energy_composite>
@@ -272,10 +272,10 @@
 
     <!-- trajectories-->
 
-	<!-- specify the name of trajectory type to be used for tracking -->
-	<define name="trajectory_name" value="trajectory_adiabatic"/>
+    <!-- specify the name of trajectory type to be used for tracking -->
+    <define name="trajectory_name" value="trajectory_adiabatic"/>
 
-	<!-- exact trajectory -->
+    <!-- exact trajectory -->
     <kstraj_trajectory_exact name="trajectory_exact" piecewise_tolerance="1e-12" max_segments="64">
         <interpolator_crk name="interpolator_crk"/>
         <integrator_rkdp853 name="integrator_rkdp853"/>
@@ -407,16 +407,16 @@
         <geo_surface name="surface_electrode_ring" surfaces="world/dipole_trap/ring">
             <command parent="root_terminator" field="add_terminator" child="term_ring"/>
         </geo_surface>
-		<loop variable="i" start="0" end="20" step="1">
+        <loop variable="i" start="0" end="20" step="1">
          <geo_surface name="surface_intermediate_z[i]" surfaces="world/dipole_trap/intermediate_z[i]"/>
-    	</loop>
-		<loop variable="i" start="0" end="20" step="1">
+        </loop>
+        <loop variable="i" start="0" end="20" step="1">
          <geo_surface name="surface_azimuthal[i]" surfaces="world/dipole_trap/azimuthal[i]"/>
-    	</loop>
+        </loop>
     </ksgeo_space>
 
-	<!-- meshed space navigator must be specified after structure so it can construct the octree -->
-	<!-- Note: if you see multiple intersections detected in the same place, you may need to increase your tolerances -->
+    <!-- meshed space navigator must be specified after structure so it can construct the octree -->
+    <!-- Note: if you see multiple intersections detected in the same place, you may need to increase your tolerances -->
     <ksnav_meshed_space
         name="nav_meshed_space"
         octree_file="dipole_octree.kbd"

--- a/Kassiopeia/XML/Examples/VTK/DipoleTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/DipoleTrapSimulation.xml
@@ -367,11 +367,13 @@
 >
     <vtk_geometry_painter
         name="geometry_painter"
+        path="[output_path]"
         file="DipoleTrapGeometry.vtp"
         surfaces="world/dipole_trap/#"
     />
     <vtk_track_painter
         name="track_painter"
+        path="[output_path]"
         file="DipoleTrapSimulation.root"
         point_object="component_step_world"
         point_variable="position"
@@ -380,6 +382,7 @@
     />
     <vtk_track_terminator_painter
         name="terminator_painter"
+        path="[output_path]"
         file="DipoleTrapSimulation.root"
         point_object="component_track_world"
         point_variable="final_position"

--- a/Kassiopeia/XML/Examples/VTK/DipoleTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/DipoleTrapSimulation.xml
@@ -254,8 +254,8 @@
 
     <!-- writers -->
 
-    <kswrite_root name="write_root" base="DipoleTrapSimulation.root"/>
-    <kswrite_vtk name="write_vtk" base="DipoleTrapSimulation"/>
+    <kswrite_root name="write_root" path="[output_path]" base="DipoleTrapSimulation.root"/>
+    <kswrite_vtk name="write_vtk" path="[output_path]" base="DipoleTrapSimulation"/>
 
     <!-- output -->
 

--- a/Kassiopeia/XML/Examples/VTK/DipoleTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/DipoleTrapSimulation.xml
@@ -4,60 +4,60 @@
 <messages>
     <file path="[log_path]" base="DipoleTrapLog.txt"/>
 
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_file" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="normal" log="normal"/>
+    <message key="ks_object" terminal="normal" log="normal"/>
     <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
+    <message key="ks_field" terminal="normal" log="normal"/>
+    <message key="ks_geometry" terminal="normal" log="normal"/>
     <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="normal"/>
+    <message key="ks_trajectory" terminal="normal" log="normal"/>
+    <message key="ks_interaction" terminal="normal" log="normal"/>
     <message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
+    <message key="ks_terminator" terminal="normal" log="normal"/>
+    <message key="ks_writer" terminal="normal" log="normal"/>
+    <message key="ks_main" terminal="normal" log="normal"/>
+    <message key="ks_run" terminal="normal" log="normal"/>
+    <message key="ks_event" terminal="normal" log="normal"/>
+    <message key="ks_track" terminal="normal" log="normal"/>
+    <message key="ks_step" terminal="normal" log="normal"/>
 
 </messages>
 
 <geometry>
 
-	<!-- world -->
+    <!-- world -->
 
-	<cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
+    <cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
 
-	<!-- solenoid -->
+    <!-- solenoid -->
 
     <tag name="magnet_tag">
         <cylinder_tube_space
-        	name="solenoid_space"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r1="0.5e-2"
-        	r2="1.5e-2"
-        	radial_mesh_count="30"
+            name="solenoid_space"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r1="0.5e-2"
+            r2="1.5e-2"
+            radial_mesh_count="30"
         />
     </tag>
 
     <!-- ring -->
 
     <tag name="electrode_tag">
-    	<cylinder_surface
-    		name="ring_surface"
-    		z1="-2.0e-2"
-    		z2="2.0e-2"
-    		r="2.5e-1"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="ring_surface"
+            z1="-2.0e-2"
+            z2="2.0e-2"
+            r="2.5e-1"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="3."
             axial_mesh_count="128"
         />
@@ -66,12 +66,12 @@
     <!-- tube -->
 
     <tag name="electrode_tag">
-    	<cylinder_surface
-    		name="tube_surface"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r="0.5e-2"
-    		longitudinal_mesh_count="200"
+        <cylinder_surface
+            name="tube_surface"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r="0.5e-2"
+            longitudinal_mesh_count="200"
             longitudinal_mesh_power="3."
             axial_mesh_count="128"
         />
@@ -92,26 +92,26 @@
     <!-- assembly -->
 
     <space name="dipole_trap_assembly">
-    	<surface name="ring" node="ring_surface"/>
+        <surface name="ring" node="ring_surface"/>
         <surface name="center" node="center_surface"/>
-    	<space name="downstream_solenoid" node="solenoid_space">
-    		<transformation displacement="0. 0. -0.5"/>
-    	</space>
-    	<surface name="downstream_tube" node="tube_surface">
-    		<transformation displacement="0. 0. -0.5"/>
-    	</surface>
-    	<surface name="upstream_target" node="target_surface">
-    		<transformation displacement="0. 0. -0.48"/>
-    	</surface>
-    	<space name="upstream_solenoid" node="solenoid_space">
-    		<transformation displacement="0. 0. 0.5"/>
-    	</space>
-    	<surface name="upstream_tube" node="tube_surface">
-    		<transformation displacement="0. 0. 0.5"/>
-    	</surface>
-    	<surface name="downstream_target" node="target_surface">
-    		<transformation displacement="0. 0. 0.48"/>
-    	</surface>
+        <space name="downstream_solenoid" node="solenoid_space">
+            <transformation displacement="0. 0. -0.5"/>
+        </space>
+        <surface name="downstream_tube" node="tube_surface">
+            <transformation displacement="0. 0. -0.5"/>
+        </surface>
+        <surface name="upstream_target" node="target_surface">
+            <transformation displacement="0. 0. -0.48"/>
+        </surface>
+        <space name="upstream_solenoid" node="solenoid_space">
+            <transformation displacement="0. 0. 0.5"/>
+        </space>
+        <surface name="upstream_tube" node="tube_surface">
+            <transformation displacement="0. 0. 0.5"/>
+        </surface>
+        <surface name="downstream_target" node="target_surface">
+            <transformation displacement="0. 0. 0.48"/>
+        </surface>
     </space>
 
     <space name="world" node="world_space">
@@ -143,7 +143,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_electromagnet
         name="field_electromagnet"
@@ -202,13 +202,13 @@
     </ksfield_electrostatic>
 
     <ksfield_electric_constant
-    	name="field_constant"
-    	field="0. 0. 0."
-	/>
+        name="field_constant"
+        field="0. 0. 0."
+    />
 
-	<!-- generators -->
+    <!-- generators -->
 
-	<ksgen_generator_composite name="generator_uniform" pid="11">
+    <ksgen_generator_composite name="generator_uniform" pid="11">
         <energy_composite>
             <energy_fix value="1."/>
         </energy_composite>

--- a/Kassiopeia/XML/Examples/VTK/PhotoMultiplierTubeSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/PhotoMultiplierTubeSimulation.xml
@@ -3,30 +3,30 @@
 
 <messages>
 
-	<file path="[log_path]" base="PhotoMultiplierTubeLog.txt"/>
+    <file path="[log_path]" base="PhotoMultiplierTubeLog.txt"/>
 
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_file" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="normal" log="normal"/>
+    <message key="ks_object" terminal="normal" log="normal"/>
     <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="normal" log="normal"/>
-	<message key="ks_interaction" terminal="normal" log="debug"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_navigator" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="normal" log="normal"/>
+    <message key="ks_field" terminal="normal" log="normal"/>
+    <message key="ks_generator" terminal="normal" log="normal"/>
+    <message key="ks_trajectory" terminal="normal" log="normal"/>
+    <message key="ks_interaction" terminal="normal" log="debug"/>
+    <message key="ks_terminator" terminal="normal" log="normal"/>
+    <message key="ks_writer" terminal="normal" log="normal"/>
+    <message key="ks_navigator" terminal="normal" log="normal"/>
+    <message key="ks_main" terminal="normal" log="normal"/>
+    <message key="ks_run" terminal="normal" log="normal"/>
+    <message key="ks_event" terminal="normal" log="normal"/>
+    <message key="ks_track" terminal="normal" log="normal"/>
+    <message key="ks_step" terminal="normal" log="normal"/>
 
 </messages>
 
@@ -62,16 +62,16 @@
     <tag name="electrode_tag" name="focusing_electrode0_tag">
         <beam_surface name="focusing_electrode0_surface">
           <beam longitudinal_mesh_count="20" axial_mesh_count="20">
-    	<define name="poly" value="120"/>
-    	<define name="fe0_r" value="{0.9*[radius]}"/>
-    	<define name="z_start_max" value="1.7e-2"/>
-    	<define name="z_start_min" value="1.2e-2"/>
-    	<define name="z_end_max" value="2.5e-2"/>
-    	<define name="z_end_min" value="2.5e-2"/>
-    	<loop variable="i" start="0" end="[poly]" step="1">
-    	  <start_line x1="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{([z_start_max]+[z_start_min])*.5 + ([z_start_max]-[z_start_min])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{([z_start_max]+[z_start_min])*.5 + ([z_start_max]-[z_start_min])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}"/>
-    	  <end_line x1="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{([z_end_max]+[z_end_min])*.5 + ([z_end_max]-[z_end_min])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{([z_end_max]+[z_end_min])*.5 + ([z_end_max]-[z_end_min])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}"/>
-    	</loop>
+        <define name="poly" value="120"/>
+        <define name="fe0_r" value="{0.9*[radius]}"/>
+        <define name="z_start_max" value="1.7e-2"/>
+        <define name="z_start_min" value="1.2e-2"/>
+        <define name="z_end_max" value="2.5e-2"/>
+        <define name="z_end_min" value="2.5e-2"/>
+        <loop variable="i" start="0" end="[poly]" step="1">
+          <start_line x1="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{([z_start_max]+[z_start_min])*.5 + ([z_start_max]-[z_start_min])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{([z_start_max]+[z_start_min])*.5 + ([z_start_max]-[z_start_min])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}"/>
+          <end_line x1="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{([z_end_max]+[z_end_min])*.5 + ([z_end_max]-[z_end_min])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe0_r]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe0_r]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{([z_end_max]+[z_end_min])*.5 + ([z_end_max]-[z_end_min])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}"/>
+        </loop>
             </beam>
         </beam_surface>
     </tag>
@@ -79,14 +79,14 @@
     <tag name="electrode_tag" name="focusing_electrode1_tag">
         <beam_surface name="focusing_electrode1_surface">
           <beam longitudinal_mesh_count="20" axial_mesh_count="20">
-    	<define name="fe1_router" value="{0.9*[radius]}"/>
-    	<define name="fe1_rinner" value="{0.5*[radius]}"/>
-    	<define name="x_inner" value="{0.17*[radius]}"/>
-    	<define name="y_inner" value="0"/>
-    	<loop variable="i" start="0" end="[poly]" step="1">
-    	  <start_line x1="{[fe1_router]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe1_router]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="0" x2="{[fe1_router]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe1_router]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="0"/>
-    	  <end_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="0" x2="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="0"/>
-    	</loop>
+        <define name="fe1_router" value="{0.9*[radius]}"/>
+        <define name="fe1_rinner" value="{0.5*[radius]}"/>
+        <define name="x_inner" value="{0.17*[radius]}"/>
+        <define name="y_inner" value="0"/>
+        <loop variable="i" start="0" end="[poly]" step="1">
+          <start_line x1="{[fe1_router]*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" y1="{[fe1_router]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="0" x2="{[fe1_router]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" y2="{[fe1_router]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="0"/>
+          <end_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="0" x2="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="0"/>
+        </loop>
             </beam>
         </beam_surface>
     </tag>
@@ -94,14 +94,14 @@
     <tag name="electrode_tag" name="focusing_electrode2_tag">
         <beam_surface name="focusing_electrode2_surface">
         <beam longitudinal_mesh_count="20" axial_mesh_count="20">
-        	<define name="z2_start" value="2.5e-2"/>
-        	<define name="z2_start_del" value="0.0"/>
-        	<define name="z2_end" value="2.3e-2"/>
-        	<define name="z2_end_del" value="0.19e-2"/>
-        	<loop variable="i" start="0" end="[poly]" step="1">
+            <define name="z2_start" value="2.5e-2"/>
+            <define name="z2_start_del" value="0.0"/>
+            <define name="z2_end" value="2.3e-2"/>
+            <define name="z2_end_del" value="0.19e-2"/>
+            <loop variable="i" start="0" end="[poly]" step="1">
              <start_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{ [z2_start] + ([z2_start_del])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe1_rinner]*TMath::Cos( 2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{ [z2_start] + ([z2_start_del])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly]) /[poly] ) }"/>
-        	  <end_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{ [z2_end] + ([z2_end_del])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{ [z2_end] + ([z2_end_del])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly] )}"/>
-        	</loop>
+              <end_line x1="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*[i]/[poly]) + [x_inner]}" y1="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*[i]/[poly])}" z1="{ [z2_end] + ([z2_end_del])*TMath::Cos(2.*TMath::Pi()*[i]/[poly])}" x2="{[fe1_rinner]*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly]) + [x_inner] }" y2="{[fe1_rinner]*TMath::Sin(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly])}" z2="{ [z2_end] + ([z2_end_del])*TMath::Cos(2.*TMath::Pi()*(([i]+1) mod [poly])/[poly] )}"/>
+            </loop>
         </beam>
         </beam_surface>
     </tag>
@@ -267,7 +267,7 @@
 
     <space name="world" node="world_space">
         <space name="photomultiplier_tube" tree="photomultiplier_tube_assembly"/>
-    	<surface name="world_boundary" node="world_surface"/>
+        <surface name="world_boundary" node="world_surface"/>
     </space>
 
 </geometry>
@@ -275,7 +275,7 @@
 
 <kassiopeia>
 
-	<!-- fields -->
+    <!-- fields -->
 
     <ksfield_electrostatic
         name="kemfield_e"
@@ -358,7 +358,7 @@
     </ksfield_electrostatic>
 
 
-    <!--	 generators -->
+    <!--     generators -->
 
     <ksgen_generator_composite name="photoelectron_single">
         <energy_composite>
@@ -379,7 +379,7 @@
     </ksgen_generator_composite>
 
 
-	<!-- trajectories-->
+    <!-- trajectories-->
 
 
     <kstraj_trajectory_exact name="trajectory_exact">

--- a/Kassiopeia/XML/Examples/VTK/QuadrupoleTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/QuadrupoleTrapSimulation.xml
@@ -6,28 +6,28 @@
     <file path="[log_path]" base="QuadrupoleTrapLog.txt"/>
 
     <message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="debug" log="normal"/>
+    <message key="ks_object" terminal="debug" log="normal"/>
     <message key="ks_operator" terminal="debug" log="normal"/>
-	<message key="ks_field" terminal="debug" log="normal"/>
-	<message key="ks_geometry" terminal="debug" log="normal"/>
+    <message key="ks_field" terminal="debug" log="normal"/>
+    <message key="ks_geometry" terminal="debug" log="normal"/>
     <message key="ks_generator" terminal="debug" log="normal"/>
-	<message key="ks_trajectory" terminal="debug" log="normal"/>
-	<message key="ks_interaction" terminal="debug" log="normal"/>
+    <message key="ks_trajectory" terminal="debug" log="normal"/>
+    <message key="ks_interaction" terminal="debug" log="normal"/>
     <message key="ks_navigator" terminal="debug" log="normal"/>
-	<message key="ks_terminator" terminal="debug" log="normal"/>
-	<message key="ks_writer" terminal="debug" log="normal"/>
-	<message key="ks_main" terminal="debug" log="normal"/>
-	<message key="ks_run" terminal="debug" log="normal"/>
-	<message key="ks_event" terminal="debug" log="normal"/>
-	<message key="ks_track" terminal="debug" log="normal"/>
-	<message key="ks_step" terminal="debug" log="normal"/>
+    <message key="ks_terminator" terminal="debug" log="normal"/>
+    <message key="ks_writer" terminal="debug" log="normal"/>
+    <message key="ks_main" terminal="debug" log="normal"/>
+    <message key="ks_run" terminal="debug" log="normal"/>
+    <message key="ks_event" terminal="debug" log="normal"/>
+    <message key="ks_track" terminal="debug" log="normal"/>
+    <message key="ks_step" terminal="debug" log="normal"/>
 
 </messages>
 
@@ -141,7 +141,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_electromagnet
         name="field_electromagnet"
@@ -198,7 +198,7 @@
         />
     </ksfield_electrostatic>
 
-	<!-- generators -->
+    <!-- generators -->
 
     <ksgen_generator_composite name="generator_fix" pid="11">
         <energy_composite>
@@ -254,7 +254,7 @@
         </time_composite>
     </ksgen_generator_composite>
 
-	<!-- trajectories-->
+    <!-- trajectories-->
 
     <kstraj_trajectory_exact name="trajectory_exact">
         <integrator_rk8 name="integrator_rk8"/>
@@ -264,7 +264,7 @@
     <kstraj_control_cyclotron name="control_cyclotron_1_16" fraction="{1. / 16.}"/>
     <kstraj_control_cyclotron name="control_cyclotron_1_64" fraction="{1. / 64.}"/>
 
-	<!-- space interactions -->
+    <!-- space interactions -->
 
     <ksint_scattering name="int_scattering" split="true">
         <density_constant temperature="300." pressure="3.e0"/>

--- a/Kassiopeia/XML/Examples/VTK/QuadrupoleTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/QuadrupoleTrapSimulation.xml
@@ -423,6 +423,7 @@
 >
     <vtk_geometry_painter
         name="geometry_painter"
+        path="[output_path]"
         surfaces="world/quadrupole_trap/#"
     />
     <vtk_track_painter

--- a/Kassiopeia/XML/Examples/VTK/ToricTrapSimulation.xml
+++ b/Kassiopeia/XML/Examples/VTK/ToricTrapSimulation.xml
@@ -6,48 +6,48 @@
 
     <file path="[log_path]" base="ToricTrapLog.txt"/>
 
-	<message key="k_file" terminal="normal" log="warning"/>
-	<message key="k_initialization" terminal="normal" log="warning"/>
+    <message key="k_file" terminal="normal" log="warning"/>
+    <message key="k_initialization" terminal="normal" log="warning"/>
 
     <message key="kg_core" terminal="normal" log="warning"/>
-	<message key="kg_shape" terminal="normal" log="warning"/>
+    <message key="kg_shape" terminal="normal" log="warning"/>
     <message key="kg_mesh" terminal="normal" log="warning"/>
     <message key="kg_axial_mesh" terminal="normal" log="warning"/>
 
-	<message key="ks_object" terminal="normal" log="normal"/>
+    <message key="ks_object" terminal="normal" log="normal"/>
     <message key="ks_operator" terminal="normal" log="normal"/>
-	<message key="ks_field" terminal="normal" log="normal"/>
-	<message key="ks_geometry" terminal="normal" log="normal"/>
+    <message key="ks_field" terminal="normal" log="normal"/>
+    <message key="ks_geometry" terminal="normal" log="normal"/>
     <message key="ks_generator" terminal="normal" log="normal"/>
-	<message key="ks_trajectory" terminal="debug" log="normal"/>
-	<message key="ks_interaction" terminal="debug" log="normal"/>
+    <message key="ks_trajectory" terminal="debug" log="normal"/>
+    <message key="ks_interaction" terminal="debug" log="normal"/>
     <message key="ks_navigator" terminal="debug" log="normal"/>
-	<message key="ks_terminator" terminal="normal" log="normal"/>
-	<message key="ks_writer" terminal="normal" log="normal"/>
-	<message key="ks_main" terminal="normal" log="normal"/>
-	<message key="ks_run" terminal="normal" log="normal"/>
-	<message key="ks_event" terminal="normal" log="normal"/>
-	<message key="ks_track" terminal="normal" log="normal"/>
-	<message key="ks_step" terminal="debug" log="normal"/>
+    <message key="ks_terminator" terminal="normal" log="normal"/>
+    <message key="ks_writer" terminal="normal" log="normal"/>
+    <message key="ks_main" terminal="normal" log="normal"/>
+    <message key="ks_run" terminal="normal" log="normal"/>
+    <message key="ks_event" terminal="normal" log="normal"/>
+    <message key="ks_track" terminal="normal" log="normal"/>
+    <message key="ks_step" terminal="debug" log="normal"/>
 
 </messages>
 
 <geometry>
 
-	<!-- world -->
+    <!-- world -->
 
-	<cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
+    <cylinder_space name="world_space" z1="-2." z2="2." r="2."/>
 
-	<!-- solenoid -->
+    <!-- solenoid -->
 
     <tag name="magnet_tag">
         <cylinder_tube_space
-        	name="solenoid_space"
-        	z1="-1.e-2"
-        	z2="1.e-2"
-        	r1="0.5e-2"
-        	r2="1.5e-2"
-        	radial_mesh_count="30"
+            name="solenoid_space"
+            z1="-1.e-2"
+            z2="1.e-2"
+            r1="0.5e-2"
+            r2="1.5e-2"
+            radial_mesh_count="30"
         />
     </tag>
 
@@ -71,10 +71,10 @@
     <!-- assembly -->
 
     <space name="toric_trap_assembly">
-    	<space name="east_solenoid" node="solenoid_space">
-    		<transformation rotation_axis_angle="90. 90. 0."/>
+        <space name="east_solenoid" node="solenoid_space">
+            <transformation rotation_axis_angle="90. 90. 0."/>
             <transformation displacement="5.0e-2 0. 0."/>
-    	</space>
+        </space>
         <space name="northeast_solenoid" node="solenoid_space">
             <transformation rotation_axis_angle="90. 90. 45."/>
             <transformation displacement="3.53553e-2 3.53553e-2 0."/>
@@ -178,7 +178,7 @@
 
 <kassiopeia>
 
-	<!-- magnetic fields -->
+    <!-- magnetic fields -->
 
     <ksfield_electromagnet
         name="field_electromagnet"
@@ -238,13 +238,13 @@
     -->
 
     <ksfield_electric_constant
-    	name="field_constant"
-    	field="0. 0. 0."
-	/>
+        name="field_constant"
+        field="0. 0. 0."
+    />
 
-	<!-- generators -->
+    <!-- generators -->
 
-	<ksgen_generator_composite name="generator_fix" pid="11">
+    <ksgen_generator_composite name="generator_fix" pid="11">
         <energy_composite>
             <energy_fix value="10."/>
         </energy_composite>
@@ -272,7 +272,7 @@
         <control_time name="control_time" time="5.e-9"/>
     </kstraj_trajectory_exact>
 
-	<!-- space interactions -->
+    <!-- space interactions -->
 
     <ksint_scattering name="int_scattering">
         <density_constant temperature="300." pressure="3.e0"/>


### PR DESCRIPTION
Without explicit output path, the default output path is chosen, which results
in permission errors on centrally installed instances where users do not have
access to e.g. /usr/local/Kassiopeia/.

Minor other changes: tabs to 4 spaces for file alignment in xml examples.