### PR TITLE
Use if/else/endif on Kassiopeia_USE_VTK selector for Examples install

### DIFF
--- a/Kassiopeia/XML/CMakeLists.txt
+++ b/Kassiopeia/XML/CMakeLists.txt
@@ -32,13 +32,13 @@ if( Kassiopeia_USE_VTK )
         Examples/VTK/ToricTrapSimulation.xml
         Examples/VTK/PhotoMultiplierTubeSimulation.xml
     )
+else( Kassiopeia_USE_VTK )
+    kasper_install_config_subdir( Examples
+        Examples/AnalyticSimulation.xml
+        Examples/QuadrupoleTrapSimulation.xml
+        Examples/DipoleTrapSimulation.xml
+        Examples/DipoleTrapMeshedSpaceSimulation.xml
+        Examples/ToricTrapSimulation.xml
+        Examples/PhotoMultiplierTubeSimulation.xml
+    )
 endif( Kassiopeia_USE_VTK )
-
-kasper_install_config_subdir( Examples
-    Examples/AnalyticSimulation.xml
-    Examples/QuadrupoleTrapSimulation.xml
-    Examples/DipoleTrapSimulation.xml
-    Examples/DipoleTrapMeshedSpaceSimulation.xml
-    Examples/ToricTrapSimulation.xml
-    Examples/PhotoMultiplierTubeSimulation.xml
-)


### PR DESCRIPTION
Without the else, the final install takes precedence and overwrites
the Examples with the non-VTK version even if Kassiopeia_USE_VTK is
set, in some cases (not sure when exactly, but consistent behavior).