### PR TITLE
Feature: Neutron beta decay recoil energy generator

### DIFF
--- a/Kassiopeia/Bindings/CMakeLists.txt
+++ b/Kassiopeia/Bindings/CMakeLists.txt
@@ -40,6 +40,7 @@ set( BINDINGS_HEADER_FILES
     Generators/Include/KSGenEnergyRadonEventBuilder.h
     Generators/Include/KSGenEnergyLeadEventBuilder.h
     Generators/Include/KSGenEnergyBetaDecayBuilder.h
+    Generators/Include/KSGenEnergyBetaRecoilBuilder.h
     Generators/Include/KSGenEnergyRydbergBuilder.h
     Generators/Include/KSGenNCompositeBuilder.h
     Generators/Include/KSGenLCompositeBuilder.h
@@ -260,6 +261,7 @@ set( BINDINGS_SOURCE_FILES
     Generators/Source/KSGenEnergyRadonEventBuilder.cxx
     Generators/Source/KSGenEnergyLeadEventBuilder.cxx
     Generators/Source/KSGenEnergyBetaDecayBuilder.cxx
+    Generators/Source/KSGenEnergyBetaRecoilBuilder.cxx
     Generators/Source/KSGenEnergyRydbergBuilder.cxx
     Generators/Source/KSGenNCompositeBuilder.cxx
     Generators/Source/KSGenLCompositeBuilder.cxx

--- a/Kassiopeia/Bindings/Generators/Include/KSGenEnergyBetaRecoilBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenEnergyBetaRecoilBuilder.h
@@ -1,0 +1,45 @@
+//
+// Created by wdconinc on 13.02.20.
+//
+
+#ifndef KASPER_KSGENENERGYBETARECOILBUILDER_H
+#define KASPER_KSGENENERGYBETARECOILBUILDER_H
+
+#include "KComplexElement.hh"
+#include "KSGenEnergyBetaRecoil.h"
+
+using namespace Kassiopeia;
+namespace katrin
+{
+
+    typedef KComplexElement< KSGenEnergyBetaRecoil > KSGenEnergyBetaRecoilBuilder;
+
+    template< >
+    inline bool KSGenEnergyBetaRecoilBuilder::AddAttribute( KContainer* aContainer )
+    {
+        if( aContainer->GetName() == "name" )
+        {
+            aContainer->CopyTo( fObject, &KNamed::SetName );
+            return true;
+        }
+        if( aContainer->GetName() == "nmax" )
+        {
+            aContainer->CopyTo( fObject, &KSGenEnergyBetaRecoil::SetNMax );
+            return true;
+        }
+        if( aContainer->GetName() == "min_energy" )
+        {
+            aContainer->CopyTo( fObject, &KSGenEnergyBetaRecoil::SetMinEnergy );
+            return true;
+        }
+        if( aContainer->GetName() == "max_energy" )
+        {
+            aContainer->CopyTo( fObject, &KSGenEnergyBetaRecoil::SetMaxEnergy );
+            return true;
+        }
+        return false;
+    }
+
+}
+
+#endif //KASPER_KSGENENERGYBETARECOILBUILDER_H

--- a/Kassiopeia/Bindings/Generators/Source/KSGenEnergyBetaRecoilBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenEnergyBetaRecoilBuilder.cxx
@@ -1,0 +1,27 @@
+//
+// Created by wdconinc on 13.02.20.
+//
+
+#include "KSGenEnergyBetaRecoilBuilder.h"
+#include "KSRootBuilder.h"
+
+using namespace Kassiopeia;
+using namespace std;
+
+namespace katrin
+{
+
+    template< >
+    KSGenEnergyBetaRecoilBuilder::~KComplexElement()
+    {
+    }
+
+    STATICINT sKSGenEnergyBetaRecoilStructure =
+            KSGenEnergyBetaRecoilBuilder::Attribute< string >( "name" ) +
+            KSGenEnergyBetaRecoilBuilder::Attribute< double >( "min_energy" ) +
+            KSGenEnergyBetaRecoilBuilder::Attribute< double >( "max_energy" );
+
+    STATICINT sKSGenEnergyBetaRecoil =
+            KSRootBuilder::ComplexElement< KSGenEnergyBetaRecoil >( "ksgen_energy_beta_recoil" );
+
+}

--- a/Kassiopeia/Bindings/Generators/Source/KSGenGeneratorCompositeBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenGeneratorCompositeBuilder.cxx
@@ -1,6 +1,7 @@
 #include "KSGenGeneratorCompositeBuilder.h"
 #include "KSGenEnergyCompositeBuilder.h"
 #include "KSGenEnergyBetaDecayBuilder.h"
+#include "KSGenEnergyBetaRecoilBuilder.h"
 #include "KSGenEnergyKryptonEventBuilder.h"
 #include "KSGenEnergyRadonEventBuilder.h"
 #include "KSGenEnergyLeadEventBuilder.h"
@@ -56,6 +57,7 @@ namespace katrin
         KSGenGeneratorCompositeBuilder::Attribute< string >( "string_id" ) +
         KSGenGeneratorCompositeBuilder::ComplexElement< KSGenEnergyComposite >( "energy_composite" ) +
         KSGenGeneratorCompositeBuilder::ComplexElement< KSGenEnergyBetaDecay >( "energy_beta_decay" ) +
+        KSGenGeneratorCompositeBuilder::ComplexElement< KSGenEnergyBetaRecoil >( "energy_beta_recoil" ) +
         KSGenGeneratorCompositeBuilder::ComplexElement< KSGenEnergyKryptonEvent >( "energy_krypton_event" ) +
         KSGenGeneratorCompositeBuilder::ComplexElement< KSGenEnergyRadonEvent >( "energy_radon_event" ) +
         KSGenGeneratorCompositeBuilder::ComplexElement< KSGenEnergyLeadEvent >( "energy_lead_event" ) +

--- a/Kassiopeia/Generators/CMakeLists.txt
+++ b/Kassiopeia/Generators/CMakeLists.txt
@@ -26,6 +26,7 @@ set( GENERATORS_HEADER_BASENAMES
     KSGenEnergyRadonEvent.h
     KSGenEnergyLeadEvent.h
     KSGenEnergyBetaDecay.h
+    KSGenEnergyBetaRecoil.h
     KSGenEnergyRydberg.h
     KSGenNComposite.h
     KSGenLComposite.h
@@ -104,6 +105,7 @@ set( GENERATORS_SOURCE_BASENAMES
     KSGenEnergyRadonEvent.cxx
     KSGenEnergyLeadEvent.cxx
     KSGenEnergyBetaDecay.cxx
+    KSGenEnergyBetaRecoil.cxx
     KSGenEnergyRydberg.cxx
     KSGenNComposite.cxx
     KSGenLComposite.cxx

--- a/Kassiopeia/Generators/Include/KSGenEnergyBetaRecoil.h
+++ b/Kassiopeia/Generators/Include/KSGenEnergyBetaRecoil.h
@@ -1,0 +1,59 @@
+//
+// Created by wdconinc on 13.02.20.
+//
+
+#ifndef KASPER_KSGENENERGYBETARECOIL_H
+#define KASPER_KSGENENERGYBETARECOIL_H
+
+#include "KSGenCreator.h"
+#include "KField.h"
+
+namespace Kassiopeia
+{
+    class KSGenEnergyBetaRecoil:
+            public KSComponentTemplate< KSGenEnergyBetaRecoil, KSGenCreator >
+    {
+    public:
+        KSGenEnergyBetaRecoil();
+        KSGenEnergyBetaRecoil( const KSGenEnergyBetaRecoil& aCopy );
+        KSGenEnergyBetaRecoil* Clone() const;
+        virtual ~KSGenEnergyBetaRecoil();
+
+        //******
+        //action
+        //******
+
+    public:
+        void Dice( KSParticleQueue* aPrimaries );
+
+        //*************
+        //configuration
+        //*************
+
+    public:
+        double g(double E);
+        double g1(double E);
+        double g2(double E);
+        double GetRecoilEnergyMax();
+        double GetRecoilEnergyProbabilityMax(double Emax);
+        double GenRecoilEnergy();
+
+    private:
+        ;K_SET_GET( int, NMax );
+        ;K_SET_GET( double, EMax );
+        ;K_SET_GET( double, PMax );
+        ;K_SET_GET( double, MinEnergy );
+        ;K_SET_GET( double, MaxEnergy );
+
+        //**********
+        //initialize
+        //**********
+
+    public:
+        void InitializeComponent();
+        void DeinitializeComponent();
+    };
+
+}
+
+#endif //KASPER_KSGENENERGYBETARECOIL_H

--- a/Kassiopeia/Generators/Source/KSGenEnergyBetaRecoil.cxx
+++ b/Kassiopeia/Generators/Source/KSGenEnergyBetaRecoil.cxx
@@ -1,0 +1,149 @@
+//
+// Created by wdconinc on 13.02.20.
+//
+
+#include "KSGenEnergyBetaRecoil.h"
+#include "KSGeneratorsMessage.h"
+
+//#include "KSParticleFactory.h"
+#include "KRandom.h"
+
+using katrin::KRandom;
+
+namespace Kassiopeia
+{
+
+    KSGenEnergyBetaRecoil::KSGenEnergyBetaRecoil() :
+            fNMax( 1000 ),
+            fEMax( 0. ),
+            fPMax( 0. ),
+            fMinEnergy( 0. ),
+            fMaxEnergy( -1. )
+    {
+    }
+    KSGenEnergyBetaRecoil::KSGenEnergyBetaRecoil( const KSGenEnergyBetaRecoil& aCopy ) :
+            KSComponent(),
+            fNMax( aCopy.fNMax ),
+            fEMax( aCopy.fEMax ),
+            fPMax( aCopy.fPMax ),
+            fMinEnergy( aCopy.fMinEnergy ),
+            fMaxEnergy( aCopy.fMaxEnergy )
+    {
+    }
+    KSGenEnergyBetaRecoil* KSGenEnergyBetaRecoil::Clone() const
+    {
+        return new KSGenEnergyBetaRecoil( *this );
+    }
+    KSGenEnergyBetaRecoil::~KSGenEnergyBetaRecoil()
+    {
+    }
+
+    void KSGenEnergyBetaRecoil::Dice( KSParticleQueue* aPrimaries )
+    {
+        KSParticleIt tParticleIt;
+
+        for( tParticleIt = aPrimaries->begin(); tParticleIt != aPrimaries->end(); tParticleIt++ )
+        {
+            double tEnergy;
+            do{
+                tEnergy = GenRecoilEnergy();
+            }while(( tEnergy < fMinEnergy) || (tEnergy > fMaxEnergy));
+
+            (*tParticleIt)->SetKineticEnergy_eV( tEnergy );
+            (*tParticleIt)->SetLabel( GetName() );
+        }
+
+        return;
+    }
+
+    double KSGenEnergyBetaRecoil::g(double E)
+    {
+        double a = -0.103;
+        double g = g1(E) + a*g2(E);
+        return g;
+    }
+
+    double KSGenEnergyBetaRecoil::g1(double E)
+    {
+        static const double Delta = KConst::M_neut_eV() - KConst::M_prot_eV();
+        static const double x = KConst::M_el_eV() / Delta;
+        static const double x2 = x * x;
+        static const double y = 2.0*KConst::M_neut_eV() / (Delta * Delta);
+        double s = 1.0 - E*y;
+        double g0 = pow(1.0 - x2/s, 2.0) * sqrt(1 - s);
+        double g1 = g0 * (4 * (1 + x2/s) - 4/3 * (s - x2)/s * (1 - s));
+        return g1;
+    }
+
+    double KSGenEnergyBetaRecoil::g2(double E)
+    {
+        static const double Delta = KConst::M_neut_eV() - KConst::M_prot_eV();
+        static const double x = KConst::M_el_eV() / Delta;
+        static const double x2 = x * x;
+        static const double y = 2.0*KConst::M_neut_eV() / (Delta * Delta);
+        double s = 1.0 - E*y;
+        double g0 = pow(1.0 - x2/s, 2.0) * sqrt(1 - s);
+        double g2 = g0 * (4 * (1 + x2/s - 2*s) - 4/3 * (s - x2)/s * (1 - s));
+        return g2;
+    }
+
+    double KSGenEnergyBetaRecoil::GetRecoilEnergyMax()
+    {
+        static const double Delta = KConst::M_neut_eV() - KConst::M_prot_eV();
+        static const double EMax = (Delta*Delta - KConst::M_el_eV()*KConst::M_el_eV()) / (2*KConst::M_neut_eV());
+        return EMax;
+    }
+
+    double KSGenEnergyBetaRecoil::GetRecoilEnergyProbabilityMax(double Emax)
+    {
+        double Pmax = 0;
+
+        for(int i=0;i<fNMax;i++){
+            double E = (Emax / double (fNMax) )*i;
+            double P = g(E) ;
+            if( P > Pmax ){
+                Pmax = P;
+            }
+        }
+        Pmax *= 1.05;
+        return Pmax;
+
+    }
+    double KSGenEnergyBetaRecoil::GenRecoilEnergy()
+    {
+        // Generation of E:
+        double E = 0;
+        double w = 0;
+
+        do{
+
+            E = KRandom::GetInstance().Uniform(fMinEnergy, fMaxEnergy);
+            w = g(E);
+
+        }while((fPMax * KRandom::GetInstance().Uniform() ) > w);
+
+        return E;
+    }
+
+
+    void KSGenEnergyBetaRecoil::InitializeComponent()
+    {
+        fEMax = GetRecoilEnergyMax();
+        fPMax = GetRecoilEnergyProbabilityMax(fEMax);
+
+        genmsg( eNormal ) << ret << "KSGenEnergyBetaRecoil::InitializeComponent E max " << fEMax << ", g max " << fPMax << eom;
+
+        if ( fMaxEnergy == -1. )
+            fMaxEnergy = fEMax;
+
+        genmsg( eNormal ) << ret << "KSGenEnergyBetaRecoil::InitializeComponent E range " << fMinEnergy << " -- " << fMaxEnergy << eom;
+
+        return;
+    }
+
+    void KSGenEnergyBetaRecoil::DeinitializeComponent()
+    {
+        return;
+    }
+
+}

--- a/Kassiopeia/Generators/Source/KSGenEnergyBetaRecoil.cxx
+++ b/Kassiopeia/Generators/Source/KSGenEnergyBetaRecoil.cxx
@@ -131,12 +131,8 @@ namespace Kassiopeia
         fEMax = GetRecoilEnergyMax();
         fPMax = GetRecoilEnergyProbabilityMax(fEMax);
 
-        genmsg( eNormal ) << ret << "KSGenEnergyBetaRecoil::InitializeComponent E max " << fEMax << ", g max " << fPMax << eom;
-
         if ( fMaxEnergy == -1. )
             fMaxEnergy = fEMax;
-
-        genmsg( eNormal ) << ret << "KSGenEnergyBetaRecoil::InitializeComponent E range " << fMinEnergy << " -- " << fMaxEnergy << eom;
 
         return;
     }


### PR DESCRIPTION
Request for comments.

Below the commit message of this feature request. This implements the energy distribution of the recoiling proton of the neutron beta decay. It is based on the beta_decay generator which generates the electron energy distribution.

I have tried to stay true to the coding coding style in the beta decay generator. I am happy to make changes to this if you feel that expanded functionality would be beneficial.

I also understand if you cannot merge this into the software for distribution.

~~~
This generator, used with the tag `energy_beta_recoil` as in
```
    <ksgen_generator_composite name="generator_uniform" pid="2212">
        <energy_beta_recoil/>
    </ksgen_generator_composite>
```
will generate an initial kinetic energy per the energy distribution
of the recoiling proton in beta decay.

The implemented expression is that of eqns 2.38ff in the PhD thesis
of Gertrud Emilie Konrad, JHU Mainz, available at
http://inspirehep.net/record/1653653/files/3053.pdf

No attempt has been made to support nuclear beta decay recoil for
anything other than simple neutron decay.

No Coulomb corrections or radiative corrections are included.