### PR TITLE
Bugfix workarounds for gcc 9 when OpenCL enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror" )
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror" )
 #set( CMAKE_EXE_LINKER_FLAG "${CMAKE_EXE_LINKER_FLAGS}" )
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new" )
+endif()
+
 if (CMAKE_BUILD_TYPE MATCHES Rel)
     option( COMPILER_TUNE_OPTIONS "Enable additional tuning options [compiles for local CPU, use with care!]" OFF )
     if( COMPILER_TUNE_OPTIONS )

--- a/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Core/include/KOpenCLBoundaryIntegrator.hh
+++ b/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Core/include/KOpenCLBoundaryIntegrator.hh
@@ -35,8 +35,10 @@ namespace KEMField
     virtual void AssignBuffers() const;
 
     mutable cl_short fShapeInfo;
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wignored-attributes"
     mutable std::vector<CL_TYPE> fShapeData;
-
+    #pragma GCC diagnostic pop
     mutable std::string fOpenCLFlags;
 
     mutable cl::Buffer *fBufferP;

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticBatchedLocalToLocalConverter_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticBatchedLocalToLocalConverter_OpenCL.hh
@@ -110,8 +110,11 @@ class KFMElectrostaticBatchedLocalToLocalConverter_OpenCL: public KFMNodeActor< 
 
         //scale factor buffers for scale invariant kernels
         double fWorldLength;
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wignored-attributes"
         std::vector< CL_TYPE > fSourceScaleFactorArray;
         std::vector< CL_TYPE > fTargetScaleFactorArray;
+        #pragma GCC diagnostic pop
         cl::Buffer* fSourceScaleFactorBufferCL;
         cl::Buffer* fTargetScaleFactorBufferCL;
 

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticBatchedRemoteToLocalConverter_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticBatchedRemoteToLocalConverter_OpenCL.hh
@@ -224,8 +224,11 @@ class KFMElectrostaticBatchedRemoteToLocalConverter_OpenCL: public KFMNodeActor<
         unsigned int fNZeroComplexArrayLocal;
 
         //scale factor buffers for scale invariant kernels
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wignored-attributes"
         std::vector< CL_TYPE > fSourceScaleFactorArray;
         std::vector< CL_TYPE > fTargetScaleFactorArray;
+        #pragma GCC diagnostic pop
         cl::Buffer* fSourceScaleFactorBufferCL;
         cl::Buffer* fTargetScaleFactorBufferCL;
 

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticBatchedRemoteToRemoteConverter_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticBatchedRemoteToRemoteConverter_OpenCL.hh
@@ -128,8 +128,11 @@ class KFMElectrostaticBatchedRemoteToRemoteConverter_OpenCL: public KFMNodeActor
 
         //scale factor buffers for scale invariant kernels
         double fWorldLength;
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wignored-attributes"
         std::vector< CL_TYPE > fSourceScaleFactorArray;
         std::vector< CL_TYPE > fTargetScaleFactorArray;
+        #pragma GCC diagnostic pop
         cl::Buffer* fSourceScaleFactorBufferCL;
         cl::Buffer* fTargetScaleFactorBufferCL;
 

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticLocalToLocalConverter_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticLocalToLocalConverter_OpenCL.hh
@@ -105,8 +105,11 @@ class KFMElectrostaticLocalToLocalConverter_OpenCL: public KFMNodeActor< KFMElec
 
         //scale factor buffers for scale invariant kernels
         double fWorldLength;
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wignored-attributes"
         std::vector< CL_TYPE > fSourceScaleFactorArray;
         std::vector< CL_TYPE > fTargetScaleFactorArray;
+        #pragma GCC diagnostic pop
         cl::Buffer* fSourceScaleFactorBufferCL;
         cl::Buffer* fTargetScaleFactorBufferCL;
 

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticRemoteToLocalConverter_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticRemoteToLocalConverter_OpenCL.hh
@@ -208,8 +208,11 @@ class KFMElectrostaticRemoteToLocalConverter_OpenCL: public KFMNodeActor< KFMEle
         unsigned int fNZeroComplexArrayLocal;
 
         //scale factor buffers for scale invariant kernels
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wignored-attributes"
         std::vector< CL_TYPE > fSourceScaleFactorArray;
         std::vector< CL_TYPE > fTargetScaleFactorArray;
+        #pragma GCC diagnostic pop
         cl::Buffer* fSourceScaleFactorBufferCL;
         cl::Buffer* fTargetScaleFactorBufferCL;
 

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticRemoteToRemoteConverter_OpenCL.hh
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/include/KFMElectrostaticRemoteToRemoteConverter_OpenCL.hh
@@ -122,8 +122,11 @@ class KFMElectrostaticRemoteToRemoteConverter_OpenCL: public KFMNodeActor< KFMEl
 
         //scale factor buffers for scale invariant kernels
         double fWorldLength;
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wignored-attributes"
         std::vector< CL_TYPE > fSourceScaleFactorArray;
         std::vector< CL_TYPE > fTargetScaleFactorArray;
+        #pragma GCC diagnostic pop
         cl::Buffer* fSourceScaleFactorBufferCL;
         cl::Buffer* fTargetScaleFactorBufferCL;
 

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/src/KFMElectrostaticBatchedRemoteToRemoteConverter_OpenCL.cc
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/src/KFMElectrostaticBatchedRemoteToRemoteConverter_OpenCL.cc
@@ -277,7 +277,10 @@ KFMElectrostaticBatchedRemoteToRemoteConverter_OpenCL::CopyMomentsToDevice()
     //send the node multipole moments to the device
     unsigned int size = fNMultipoleNodes*fStride;
 
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wignored-attributes"
     std::vector< std::complex<CL_TYPE> > moments;
+    #pragma GCC diagnostic pop
     moments.resize(size);
 
     //now distribute the primary node moments
@@ -288,7 +291,10 @@ KFMElectrostaticBatchedRemoteToRemoteConverter_OpenCL::CopyMomentsToDevice()
 
         if(set != NULL)
         {
+            #pragma GCC diagnostic push
+            #pragma GCC diagnostic ignored "-Wignored-attributes"
             std::complex<CL_TYPE> temp;
+            #pragma GCC diagnostic pop
             //we use raw ptr for speed
             double* rmoments = &( (*(set->GetRealMoments()))[0] );
             double* imoments = &( (*(set->GetImaginaryMoments()))[0] );
@@ -315,7 +321,10 @@ KFMElectrostaticBatchedRemoteToRemoteConverter_OpenCL::RecieveMomentsFromDevice(
     //read the node multipole coefficients back from the device
     unsigned int size = fNMultipoleNodes*fStride;
 
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wignored-attributes"
     std::vector< std::complex<CL_TYPE> > moments;
+    #pragma GCC diagnostic pop
     moments.resize(size);
 
     KOpenCLInterface::GetInstance()->GetQueue().enqueueReadBuffer(*fNodeMomentBufferCL, CL_TRUE, 0, size*sizeof(CL_TYPE2), &(moments[0]) );

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/src/KFMElectrostaticMultipoleBatchCalculator_OpenCL.cc
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/src/KFMElectrostaticMultipoleBatchCalculator_OpenCL.cc
@@ -182,6 +182,8 @@ KFMElectrostaticMultipoleBatchCalculator_OpenCL::ConstructOpenCLKernels()
 void
 KFMElectrostaticMultipoleBatchCalculator_OpenCL::BuildBuffers()
 {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Waligned-new="
     //origin data
     fIntermediateOriginData = new CL_TYPE4[fNMaxItems];
 
@@ -333,6 +335,7 @@ KFMElectrostaticMultipoleBatchCalculator_OpenCL::BuildBuffers()
     }
     CL_ERROR_CATCH
 
+    #pragma GCC diagnostic pop
 }
 
 

--- a/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/src/KFMElectrostaticRemoteToRemoteConverter_OpenCL.cc
+++ b/KEMField/Source/Plugins/OpenCL/FastMultipole/Electrostatics/src/KFMElectrostaticRemoteToRemoteConverter_OpenCL.cc
@@ -258,7 +258,10 @@ void KFMElectrostaticRemoteToRemoteConverter_OpenCL::Prepare()
     //send the node multipole moments to the device
     unsigned int size = fNMultipoleNodes*fStride;
 
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wignored-attributes"
     std::vector< std::complex<CL_TYPE> > moments;
+    #pragma GCC diagnostic pop
     moments.resize(size);
 
     //now distribute the primary node moments
@@ -269,7 +272,10 @@ void KFMElectrostaticRemoteToRemoteConverter_OpenCL::Prepare()
 
         if(set != NULL)
         {
+            #pragma GCC diagnostic push
+            #pragma GCC diagnostic ignored "-Wignored-attributes"
             std::complex<CL_TYPE> temp;
+            #pragma GCC diagnostic pop
             //we use raw ptr for speed
             double* rmoments = &( (*(set->GetRealMoments()))[0] );
             double* imoments = &( (*(set->GetImaginaryMoments()))[0] );
@@ -296,7 +302,10 @@ void KFMElectrostaticRemoteToRemoteConverter_OpenCL::Finalize()
     //read the node multipole coefficients back from the device
     unsigned int size = fNMultipoleNodes*fStride;
 
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wignored-attributes"
     std::vector< std::complex<CL_TYPE> > moments;
+    #pragma GCC diagnostic pop
     moments.resize(size);
 
     KOpenCLInterface::GetInstance()->GetQueue().enqueueReadBuffer(*fNodeMomentBufferCL, CL_TRUE, 0, size*sizeof(CL_TYPE2), &(moments[0]) );

--- a/KEMField/Source/Plugins/OpenCL/Surfaces/include/KOpenCLSurfaceContainer.hh
+++ b/KEMField/Source/Plugins/OpenCL/Surfaces/include/KOpenCLSurfaceContainer.hh
@@ -78,11 +78,14 @@ namespace KEMField
     unsigned int fBoundarySize;
     unsigned int fBasisSize;
 
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wignored-attributes"
     std::vector<cl_short>  fShapeInfo;
     std::vector<CL_TYPE>   fShapeData;
     std::vector<cl_int>    fBoundaryInfo;
     std::vector<CL_TYPE>   fBoundaryData;
     std::vector<CL_TYPE>   fBasisData;
+    #pragma GCC diagnostic pop
 
     cl::Buffer* fBufferShapeInfo;
     cl::Buffer* fBufferShapeData;


### PR DESCRIPTION
Two symptomatic fixes:
- Suppress -Wignored-attributes on all occurrences of std::vector<CL_TYPE>
- Use -faligned-new flag to trick gcc into using aligned allocators for CL types

Note: This is not stress tested, but it compiles, runs, and produces reasonable output for my use case. No guarantees on anything other than the system I am using.

The underlying concern here is that the CL_TYPEs have attributes to indicate alignment on specific byte boundaries (e.g. `typedef double cl_double  __attribute__((aligned(8)));`) which are ignored by std::vector. I am not enough of an expert to determine what the proper resolution is.