### PR TITLE
Bugfix: Throw errors in FieldMapX and FieldMapZ instead of Render

### DIFF
--- a/Kassiopeia/Visualization/Source/KSROOTMagFieldPainter.cxx
+++ b/Kassiopeia/Visualization/Source/KSROOTMagFieldPainter.cxx
@@ -146,7 +146,7 @@ namespace Kassiopeia
 						}
 					}
 					else{
-						vismsg ( eError ) << "do not know what to plot" << eom;
+						vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
 					}
 				}
 			}
@@ -270,7 +270,7 @@ namespace Kassiopeia
 						}
 					}
 					else{
-						vismsg ( eError ) << "do not know what to plot" << eom;
+						vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
 					}
 				}
 			}
@@ -400,7 +400,7 @@ namespace Kassiopeia
 					}
 				}
 				else {
-					vismsg( eError ) << "do not know what to plot" << eom;
+					vismsg( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
 				}
 			}
 		}
@@ -414,8 +414,6 @@ namespace Kassiopeia
 		KSMagneticField* tMagField = getMagneticField( fMagneticFieldName );
 		if ( tMagField == NULL)
 			vismsg(eError) << "No magnetic Field!" << eom;
-		if ( fPlot!="magnetic_field_abs" && fPlot!="magnetic_field_x" && fPlot!="magnetic_field_x_abs"&& fPlot!="magnetic_field_y" && fPlot!="magnetic_field_y_abs" && fPlot!="magnetic_field_z" && fPlot!="magnetic_field_z_abs" && fPlot!="magnetic_potential_abs" && fPlot!="magnetic_gradient_z" && fPlot!="magnetic_gradient_z_abs" && fPlot!="magnetic_gradient_x" && fPlot!="magnetic_gradient_x_abs" && fPlot!="magnetic_gradient_y" && fPlot!="magnetic_gradient_y_abs" )
-			vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
 		vismsg(eNormal) << "Initialize magnetic field (again)" << eom;
 		tMagField->Initialize();
 

--- a/Kassiopeia/Visualization/Source/KSROOTMagFieldPainter.cxx
+++ b/Kassiopeia/Visualization/Source/KSROOTMagFieldPainter.cxx
@@ -114,6 +114,9 @@ namespace Kassiopeia
 								Map->SetBinContent(i+1,fRsteps-j+1, tGradient );
 								Map->SetBinContent(i+1,fRsteps+j+1, tGradient );
 							}
+		                                        else{
+		                                                vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
+		                                        }
 						}
 						else if( fGradNumerical==false){
 //							calculate gradient matrix
@@ -143,6 +146,9 @@ namespace Kassiopeia
 								Map->SetBinContent(i+1,fRsteps-j+1, fabs(tGradB.X()) );
 								Map->SetBinContent(i+1,fRsteps+j+1, fabs(tGradB.X()) );
 							}
+		                                        else{
+		                                                vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
+		                                        }
 						}
 					}
 					else{
@@ -237,6 +243,9 @@ namespace Kassiopeia
 								Double_t tGradient = fabs((tMagneticField_y.Magnitude()-tMagneticField.Magnitude())/tDeltaR);
 								Map->SetBinContent(i+1,fRsteps+j+1, tGradient );
 							}
+		                                        else{
+		                                                vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
+		                                        }
 						}
 						else if( fGradNumerical==false){
 //							calculate gradient matrix
@@ -267,11 +276,14 @@ namespace Kassiopeia
 							else if( fPlot=="magnetic_gradient_y_abs" ){
 								Map->SetBinContent(i+1,fRsteps+j+1, fabs(tGradB.Y()) );
 							}
+		                                        else{
+		                                                vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
+		                                        }
 						}
 					}
-					else{
-						vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
-					}
+                                        else{
+                                                vismsg ( eError ) << "do not know what to plot, plot=<"<<fPlot<<"> is not defined in KSROOTMagFieldPainter" << eom;
+                                        }
 				}
 			}
 		}


### PR DESCRIPTION
When checking for valid arguments for `plot="magnetic_gradient_abs"` arguments to the root_magfield_painter, the check was previously done by a list of valid arguments in Render. The list got out of date and "magnetic_gradient_abs", for example, was not recognized. By moving the errors into the FieldMapX and FieldMapZ functions, the error will be thrown when a plot keyword is not recognized without having to keep track of a list elsewhere.