### PR TITLE
Use Kassiopeia_USE_ROOT instead of KASSIOPEIA_USE_ROOT

### DIFF
--- a/Kassiopeia/Bindings/Generators/Source/KSGenLCompositeBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenLCompositeBuilder.cxx
@@ -6,7 +6,7 @@
 #include "KSGenValueGaussBuilder.h"
 #include "KSRootBuilder.h"
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
 #include "KSGenValueFormulaBuilder.h"
 #endif
 
@@ -33,7 +33,7 @@ namespace katrin
     STATICINT sKSGenLComposite =
         KSRootBuilder::ComplexElement< KSGenLComposite >( "ksgen_l_composite" );
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
     STATICINT sKSGenLCompositeStructureROOT =
             KSGenLCompositeBuilder::ComplexElement< KSGenValueFormula >( "l_formula" );
 #endif

--- a/Kassiopeia/Bindings/Generators/Source/KSGenMomentumRectangularCompositeBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenMomentumRectangularCompositeBuilder.cxx
@@ -6,7 +6,7 @@
 #include "KSGenValueGaussBuilder.h"
 #include "KSRootBuilder.h"
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
 #include "KSGenValueFormulaBuilder.h"
 #include "KSGenValueHistogramBuilder.h"
 #endif
@@ -48,7 +48,7 @@ namespace katrin
     STATICINT sToolboxKSGenMomentumRectangularComposite =
         KSRootBuilder::ComplexElement< KSGenMomentumRectangularComposite >( "ksgen_momentum_rectangular_composite" );
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
     STATICINT sKSGenPositionRectangularCompositeStructureROOT =
             KSGenMomentumRectangularCompositeBuilder::ComplexElement< KSGenValueFormula >( "x_formula" ) +
             KSGenMomentumRectangularCompositeBuilder::ComplexElement< KSGenValueHistogram >( "x_histogram" ) +

--- a/Kassiopeia/Bindings/Generators/Source/KSGenNCompositeBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenNCompositeBuilder.cxx
@@ -7,7 +7,7 @@
 #include "KSGenValueParetoBuilder.h"
 #include "KSRootBuilder.h"
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
 #include "KSGenValueFormulaBuilder.h"
 #endif
 
@@ -35,7 +35,7 @@ namespace katrin
     STATICINT sKSGenNComposite =
         KSRootBuilder::ComplexElement< KSGenNComposite >( "ksgen_n_composite" );
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
     STATICINT sKSGenNCompositeStructureROOT =
             KSGenNCompositeBuilder::ComplexElement< KSGenValueFormula >( "n_formula" );
 #endif

--- a/Kassiopeia/Bindings/Generators/Source/KSGenPositionFluxTubeBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenPositionFluxTubeBuilder.cxx
@@ -7,7 +7,7 @@
 #include "KSGenValueUniformBuilder.h"
 #include "KSGenValueGaussBuilder.h"
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
 #include "KSGenValueFormulaBuilder.h"
 #endif
 
@@ -39,7 +39,7 @@ namespace katrin
 		KSGenPositionFluxTubeBuilder::ComplexElement< KSGenValueUniform >( "z_uniform" ) +
 		KSGenPositionFluxTubeBuilder::ComplexElement< KSGenValueGauss >( "z_gauss" );
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
     STATICINT sKSGenPositionFluxTubeStructureROOT =
     		KSGenPositionFluxTubeBuilder::ComplexElement< KSGenValueFormula >( "r_formula" ) +
     		KSGenPositionFluxTubeBuilder::ComplexElement< KSGenValueFormula >( "z_formula" );

--- a/Kassiopeia/Bindings/Generators/Source/KSGenTimeCompositeBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenTimeCompositeBuilder.cxx
@@ -7,7 +7,7 @@
 #include "KSGenValueGeneralizedGaussBuilder.h"
 #include "KSRootBuilder.h"
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
 #include "KSGenValueFormulaBuilder.h"
 #include "KSGenValueHistogramBuilder.h"
 #endif
@@ -36,7 +36,7 @@ namespace katrin
     STATICINT sKSGenTimeComposite =
         KSRootBuilder::ComplexElement< KSGenTimeComposite >( "ksgen_time_composite" );
 
-#ifdef KASSIOPEIA_USE_ROOT
+#ifdef Kassiopeia_USE_ROOT
     STATICINT sKSGenTimeCompositeStructureROOT =
             KSGenTimeCompositeBuilder::ComplexElement< KSGenValueFormula >( "time_formula" ) +
             KSGenTimeCompositeBuilder::ComplexElement< KSGenValueHistogram >( "time_histogram" );


### PR DESCRIPTION
Some bindings have ifdef guards with KASSIOPEIA_USE_ROOT, however in
Kassiopeia/CMakeLists.txt the line `SET( Kassiopeia_USE_ROOT
${KASPER_USE_ROOT} )` sets Kassiopeia_USE_ROOT. This causes the bindings
for, for example, momentum_rectangular_composite not to accept histogram
input on case sensitive compilers.

This bugfix replaces all instances of KASSIOPEIA_USE_ROOT with
Kassiopeia_USE_ROOT.