### PR TITLE
Feature: Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+.cache
+.project
+.settings
+.cproject
+build
+install
+Dockerfile
+.dockerignore

--- a/Docker/packages.build
+++ b/Docker/packages.build
@@ -1,0 +1,13 @@
+binutils
+cmake
+make
+gcc
+gcc-c++
+gsl-devel
+boost-devel
+zlib-devel
+libxml2-devel
+tbb-devel
+vtk-devel
+ocl-icd-devel
+root-core

--- a/Docker/packages.runtime
+++ b/Docker/packages.runtime
@@ -1,0 +1,7 @@
+tbb
+vtk
+vtk-qt
+vtk-java
+boost-filesystem
+ocl-icd
+root-core

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+FROM fedora:31 as runtime-base
+
+LABEL description="Runtime base container"
+LABEL maintainer=wdconinc@gmail.com
+
+COPY Docker/packages.runtime packages
+RUN dnf update -y \
+ && dnf install -y $(cat packages) \
+ && rm /packages
+
+
+FROM runtime-base as build-base
+
+LABEL description="Build base container"
+LABEL maintainer=wdconinc@gmail.com
+
+COPY Docker/packages.build packages
+RUN dnf update -y \
+ && dnf install -y $(cat packages) \
+ && rm /packages
+
+
+FROM build-base as build
+
+LABEL description="Build container"
+LABEL maintainer=wdconinc@gmail.com
+
+COPY . .
+RUN mkdir -p build && \
+    pushd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DKASPER_USE_ROOT=ON \
+          -DKASPER_USE_VTK=ON \
+          -DKASPER_USE_TBB=ON \
+          -DKEMField_USE_OPENCL=OFF \
+       .. && \
+    make -j $((($(nproc)+1)/2)) && \
+    make install && \
+    popd
+
+
+FROM runtime-base as runtime
+
+LABEL description="Run container"
+LABEL maintainer=wdconinc@gmail.com
+
+COPY --from=build /usr/local /usr/local
+RUN echo "/usr/local/lib64" > /etc/ld.so.conf.d/local-x86_64.conf \
+ && ldconfig
+
+WORKDIR /usr/local
+
+RUN echo '#!/bin/bash' >  /usr/local/bin/entrypoint.sh && \
+    echo 'exec "$@"'   >> /usr/local/bin/entrypoint.sh && \
+    chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/usr/local/bin/entrypoint.sh","Kassiopeia"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,9 @@ RUN strip --remove-section=.note.ABI-tag /usr/lib64/libQt5Core.so.5
 
 WORKDIR /usr/local
 
-RUN echo '#!/bin/bash' >  /usr/local/bin/entrypoint.sh && \
-    echo 'exec "$@"'   >> /usr/local/bin/entrypoint.sh && \
+RUN echo '#!/bin/bash'                         >  /usr/local/bin/entrypoint.sh && \
+    echo '. /usr/local/bin/kasperenv.sh `pwd`' >> /usr/local/bin/entrypoint.sh && \
+    echo 'exec "$@"'                           >> /usr/local/bin/entrypoint.sh && \
     chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ LABEL maintainer=wdconinc@gmail.com
 COPY --from=build /usr/local /usr/local
 RUN echo "/usr/local/lib64" > /etc/ld.so.conf.d/local-x86_64.conf \
  && ldconfig
+RUN strip --remove-section=.note.ABI-tag /usr/lib64/libQt5Core.so.5
 
 WORKDIR /usr/local
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,32 @@ Kassiopeia: Simulation of electric and magnetic fields and particle tracking
 
 
 --------------------------------------------------
+ Docker container
+--------------------------------------------------
+
+    1. A Docker container with Kasper is available at
+        https://hub.docker.com/r/katrinexperiment/kassiopeia
+    2. This Docker container can be used with Docker
+       (with superuser privileges).
+        A. Pull the container to your system with
+            > sudo docker pull katrinexperiment/kassiopeia
+        B. Open a shell inside the container with
+            > sudo docker run --rm -it katrinexperiment/kassiopeia /bin/bash
+    3. The Docker container can also be used with Singularity
+       (as a regular user).
+        A. Pull the container to your system with
+            > singularity pull docker://katrinexperiment/kassiopeia
+        B. Open a shell inside the container with
+            > singularity shell docker://katrinexperiment/kassiopeia
+           or (if a local copy is available already)
+            > singularity shell kassiopeia-latest.sif
+    4. Build the container locally with
+        > sudo docker build -t katrinexperiment/kassiopeia .
+       and upload the local container to Docker Hub with
+        > sudo docker push katrinexperiment/kassiopeia
+
+
+--------------------------------------------------
  Documentation
 --------------------------------------------------
 


### PR DESCRIPTION
This PR provides a Dockerfile for a working docker container for Kassiopeia. It includes instructions in README.md on how to use pull, run and build the container.

The Docker Hub organization katrinexperiment has been reserved (https://hub.docker.com/r/katrinexperiment/kassiopeia), and ownership will be transfered if you let me know what Docker username to transfer it to. It seemed more appropriate than referring to https://hub.docker.com/r/wdconinc/kassiopeia in the central repository. Docker Hub does not allow dashes or uppercase letters in organization names.

The container inherits from the Fedora 31 base image. The container is a multi-stage build so it only contains the installed final build products in the container, not the source code or intermediate build objects. Build dependencies and runtime dependencies are separated out in two files in the Docker directory (these could be hardcoded in the Dockerfile as well).

OpenCL is not currently enabled in the container. I had no way of testing this reliably and encountered some build problems on the Fedora image.

Note: We are using this container for cluster jobs on Compute Canada's high performance computing clusters with singularity. It greatly simplifies running on those systems since we don't have to worry about compiling and installing the software in local directories. Essentially:
```
cd $SCRATCH
./kassiopeia_latest.sif create_kasper_user_directory.sh .
./kassiopeia_latest.sif Kassiopeia simulation.xml -r seed=${JOB_ID}
```