### PR TITLE
Bugfix: If CL_TYPE is set to float, we don't want narrowing warnings

### DIFF
--- a/KEMField/Source/Plugins/OpenCL/Core/include/KOpenCLInterface.hh
+++ b/KEMField/Source/Plugins/OpenCL/Core/include/KOpenCLInterface.hh
@@ -52,6 +52,7 @@
 #define CL_TYPE4 cl_float4
 #define CL_TYPE8 cl_float8
 #define CL_TYPE16 cl_float16
+#pragma GCC diagnostic ignored "-Wnarrowing"
 #endif
 
 #include <vector>


### PR DESCRIPTION
On gcc-9, with `-DKEMField_USE_OPENCL=ON` and `-Werror` in CMakeLists.txt, the narrowing from doubles to CL_TYPE in initializer lists results in an error, e.g. https://github.com/KATRIN-Experiment/Kassiopeia/blob/4065e02e04f627c37ae306e77268edf275c4d7c8/KEMField/Source/Plugins/OpenCL/BoundaryIntegrals/Electrostatic/include/KOpenCLElectrostaticBoundaryIntegrator.hh#L136, 
```
template <class SourceShape>
double KOpenCLElectrostaticBoundaryIntegrator::Potential(const SourceShape* source,const KPosition& aPosition) const
  {
    StreamSourceToBuffer(source);

    CL_TYPE P[3] = {aPosition[0],aPosition[1],aPosition[2]};
```
with KPosition using double.

This fix just pushes GCC to ignore "-Wnarrowing". This may not fix compilation on other compilers, but then again, maybe the warning doesn't result in an error there either.
