### PR TITLE
OpenCL warns unless CL_TARGET_OPENCL_VERSION is set to target version

### DIFF
--- a/KEMField/Source/Plugins/OpenCL/Core/include/KOpenCLHeaderWrapper.hh
+++ b/KEMField/Source/Plugins/OpenCL/Core/include/KOpenCLHeaderWrapper.hh
@@ -11,6 +11,7 @@
 #if defined __APPLE__
 #include <OpenCL/cl.hpp>
 #else
+#define CL_TARGET_OPENCL_VERSION 120
 #include <CL/cl.hpp>
 #endif
 

--- a/KEMField/Source/Plugins/OpenCL/Core/src/GenerateOpenCLHeader.cc
+++ b/KEMField/Source/Plugins/OpenCL/Core/src/GenerateOpenCLHeader.cc
@@ -9,6 +9,7 @@
 #if defined __APPLE__
 #include <OpenCL/cl.hpp>
 #else
+#define CL_TARGET_OPENCL_VERSION 120
 #include <CL/cl.hpp>
 #endif
 #include <algorithm>


### PR DESCRIPTION
This defines the target to OpenCL 1.2 on all non-__APPLE__ systems (which I have no way to test). Without an explicit version, there are warnings every time cl.hpp is included.