### PR TITLE
Bugfix: KSRead for long long type

### DIFF
--- a/Kassiopeia/Generators/Source/KSGenGeneratorSimulation.cxx
+++ b/Kassiopeia/Generators/Source/KSGenGeneratorSimulation.cxx
@@ -247,7 +247,7 @@ void KSGenGeneratorSimulation::GenerateParticlesFromFile(KSParticleQueue& aParti
                     tTime = tTrackGroup.Get<KSDouble>(fTimeName).Value();
                 }
                 if (!fPIDName.empty()) {
-                    tPID = tTrackGroup.Get<KSInt>(fPIDName).Value();
+                    tPID = tTrackGroup.Get<KSLongLong>(fPIDName).Value();
                 }
 
                 if (fFormulaPositionX != nullptr)

--- a/Kassiopeia/Readers/Include/KSReadIteratorROOT.h
+++ b/Kassiopeia/Readers/Include/KSReadIteratorROOT.h
@@ -16,6 +16,7 @@ class KSReadIteratorROOT :
     public KSIntSet,
     public KSULongSet,
     public KSLongSet,
+    public KSLongLongSet,
     public KSFloatSet,
     public KSDoubleSet,
     public KSThreeVectorSet,

--- a/Kassiopeia/Readers/Include/KSReadObjectROOT.h
+++ b/Kassiopeia/Readers/Include/KSReadObjectROOT.h
@@ -18,6 +18,7 @@ class KSReadObjectROOT :
     public KSIntSet,
     public KSULongSet,
     public KSLongSet,
+    public KSLongLongSet,
     public KSFloatSet,
     public KSDoubleSet,
     public KSThreeVectorSet,

--- a/Kassiopeia/Readers/Include/KSReadSet.h
+++ b/Kassiopeia/Readers/Include/KSReadSet.h
@@ -74,6 +74,7 @@ typedef KSReadSet<KSReadValue<unsigned int>> KSUIntSet;
 typedef KSReadSet<KSReadValue<int>> KSIntSet;
 typedef KSReadSet<KSReadValue<unsigned long>> KSULongSet;
 typedef KSReadSet<KSReadValue<long>> KSLongSet;
+typedef KSReadSet<KSReadValue<long long>> KSLongLongSet;
 typedef KSReadSet<KSReadValue<float>> KSFloatSet;
 typedef KSReadSet<KSReadValue<double>> KSDoubleSet;
 typedef KSReadSet<KSReadValue<KThreeVector>> KSThreeVectorSet;

--- a/Kassiopeia/Readers/Include/KSReadValue.h
+++ b/Kassiopeia/Readers/Include/KSReadValue.h
@@ -170,6 +170,7 @@ typedef KSReadValue<unsigned int> KSUInt;
 typedef KSReadValue<int> KSInt;
 typedef KSReadValue<unsigned long> KSULong;
 typedef KSReadValue<long> KSLong;
+typedef KSReadValue<long long> KSLongLong;
 typedef KSReadValue<float> KSFloat;
 typedef KSReadValue<double> KSDouble;
 typedef KSReadValue<KThreeVector> KSThreeVector;
@@ -193,6 +194,8 @@ template<> const KSInt KSInt::sZero;
 template<> const KSULong KSULong::sZero;
 
 template<> const KSLong KSLong::sZero;
+
+template<> const KSLongLong KSLongLong::sZero;
 
 template<> const KSFloat KSFloat::sZero;
 

--- a/Kassiopeia/Readers/Source/KSReadIterator.cxx
+++ b/Kassiopeia/Readers/Source/KSReadIterator.cxx
@@ -21,6 +21,8 @@ template<> const KSULong KSULong::sZero(0);
 
 template<> const KSLong KSLong::sZero(0);
 
+template<> const KSLongLong KSLongLong::sZero(0);
+
 template<> const KSFloat KSFloat::sZero(0.);
 
 template<> const KSDouble KSDouble::sZero(0);

--- a/Kassiopeia/Readers/Source/KSReadObjectROOT.cxx
+++ b/Kassiopeia/Readers/Source/KSReadObjectROOT.cxx
@@ -68,6 +68,10 @@ KSReadObjectROOT::KSReadObjectROOT(TTree* aStructureTree, TTree* aPresenceTree, 
             fData->SetBranchAddress(tLabel.c_str(), Add<KSLong>(tLabel).Pointer());
             continue;
         }
+        if (tType == string("long long")) {
+            fData->SetBranchAddress(tLabel.c_str(), Add<KSLongLong>(tLabel).Pointer());
+            continue;
+        }
 
         if (tType == string("float")) {
             fData->SetBranchAddress(tLabel.c_str(), Add<KSFloat>(tLabel).Pointer());


### PR DESCRIPTION
This introduces KSLongLong in reading ROOT files in the KSGenGeneratorSimulation. In particular, the PID values are written as long long.