### PR TITLE
[bugfix] std::vector empty() just checks for emtpiness; clear() acts on the vector

### DIFF
--- a/KGeoBag/Source/Extensions/Mesh/Complex/Source/KGConicSectPortHousingSurfaceMesher.cc
+++ b/KGeoBag/Source/Extensions/Mesh/Complex/Source/KGConicSectPortHousingSurfaceMesher.cc
@@ -817,7 +817,7 @@ void KGConicSectPortHousingSurfaceMesher::ParaxialPortDiscretizer::DiscretizePor
     // cylindrical portion of the valve
 
     if (paraxialPort->GetAsymmetricLength() < paraxialPort->GetSymmetricLength()) {
-        dz.empty();
+        dz.clear();
         dz.resize(2 * paraxialPort->GetCylDisc());
         DiscretizeInterval(2. * (paraxialPort->GetSymmetricLength() - paraxialPort->GetAsymmetricLength() / 2.),
                            2 * paraxialPort->GetCylDisc(),
@@ -1236,7 +1236,7 @@ void KGConicSectPortHousingSurfaceMesher::OrthogonalPortDiscretizer::DiscretizeP
     // now that the tricky part's over, we have only to finish discretizing the
     // cylindrical portion of the valve
 
-    dz.empty();
+    dz.clear();
     dz.resize(2 * orthogonalPort->GetCylDisc());
     DiscretizeInterval(2. * (orthogonalPort->GetLength() - merge_length), 2 * orthogonalPort->GetCylDisc(), 1.25, dz);
 

--- a/KGeoBag/Source/Extensions/Mesh/Complex/Source/KGPortHousingSurfaceMesher.cc
+++ b/KGeoBag/Source/Extensions/Mesh/Complex/Source/KGPortHousingSurfaceMesher.cc
@@ -1063,7 +1063,7 @@ void KGPortHousingSurfaceMesher::CircularPortDiscretizer::DiscretizePort(
     // cylindrical portion of the valve
 
     if (sub_length > merge_length) {
-        dz.empty();
+        dz.clear();
         dz.resize(circularPort->GetNumDiscSub());
         DiscretizeInterval(sub_length - merge_length, circularPort->GetNumDiscSub(), 1, dz);
 


### PR DESCRIPTION
The lines with `dz.empty()` generate a compilation error on gcc-10 due to `-Werror` and `-Wunused-result` in particular. Instead of `dz.empty()` I suspect it should be `dz.clear()`.

References:
- [bool empty()](http://www.cplusplus.com/reference/vector/vector/empty/)
- [void clear()](http://www.cplusplus.com/reference/vector/vector/clear/)

Compilation error:
```
[ 25%] Built target KGeoBagRandom
/home/wdconinc/git/Kassiopeia/KGeoBag/Source/Extensions/Mesh/Complex/Source/KGConicSectPortHousingSurfaceMesher.cc: In member function ‘void KGeoBag::KGConicSectPortHousingSurfaceMesher::ParaxialPortDiscretizer::DiscretizePort(const KGeoBag::KGConicSectPortHousing::ParaxialPort*)’:
/home/wdconinc/git/Kassiopeia/KGeoBag/Source/Extensions/Mesh/Complex/Source/KGConicSectPortHousingSurfaceMesher.cc:820:17: error: ignoring return value of ‘bool std::vector<_Tp, _Alloc>::empty() const [with _Tp = double; _Alloc = std::allocator<double>]’, declared with attribute ‘nodiscard’ [-Werror=unused-result]
  820 |         dz.empty();
      |         ~~~~~~~~^~
In file included from /usr/include/c++/10/vector:67,
                 from /usr/include/c++/10/functional:62,
                 from /usr/include/c++/10/pstl/glue_algorithm_defs.h:13,
                 from /usr/include/c++/10/algorithm:74,
                 from /home/wdconinc/git/Kassiopeia/KGeoBag/Source/Math/SpaceTree/Include/KGPoint.hh:4,
                 from /home/wdconinc/git/Kassiopeia/KGeoBag/Source/Math/SpaceTree/Include/KGPointCloud.hh:4,
                 from /home/wdconinc/git/Kassiopeia/KGeoBag/Source/Extensions/Mesh/Include/KGMeshElement.hh:4,
                 from /home/wdconinc/git/Kassiopeia/KGeoBag/Source/Extensions/Mesh/Include/KGMeshRectangle.hh:4,
                 from /home/wdconinc/git/Kassiopeia/KGeoBag/Source/Extensions/Mesh/Complex/Include/KGComplexMesher.hh:4,
                 from /home/wdconinc/git/Kassiopeia/KGeoBag/Source/Extensions/Mesh/Complex/Include/KGConicSectPortHousingSurfaceMesher.hh:4,
                 from /home/wdconinc/git/Kassiopeia/KGeoBag/Source/Extensions/Mesh/Complex/Source/KGConicSectPortHousingSurfaceMesher.cc:1:
/usr/include/c++/10/bits/stl_vector.h:1007:7: note: declared here
 1007 |       empty() const _GLIBCXX_NOEXCEPT
      |       ^~~~~
```