### PR TITLE
[bugfix] avoid hard crash when gradient not present in maps

### DIFF
--- a/KEMField/Source/Plugins/VTKPart2/src/KElectrostaticPotentialmap.cc
+++ b/KEMField/Source/Plugins/VTKPart2/src/KElectrostaticPotentialmap.cc
@@ -43,6 +43,7 @@ KPotentialMapVTK::~KPotentialMapVTK() {}
 bool KPotentialMapVTK::GetValue(const string& array, const KPosition& aSamplePoint, double* aValue) const
 {
     vtkDataArray* data = fImageData->GetPointData()->GetArray(array.c_str());
+    if (data == nullptr) return false;
 
     // get coordinates of closest mesh point
     vtkIdType center = fImageData->FindPoint((double*) (aSamplePoint.Components()));
@@ -91,6 +92,7 @@ bool KLinearInterpolationPotentialMapVTK::GetValue(const string& array, const KP
                                                    double* aValue) const
 {
     vtkDataArray* data = fImageData->GetPointData()->GetArray(array.c_str());
+    if (data == nullptr) return false;
 
     // get coordinates of surrounding mesh points
     static const char map[8][3] = {
@@ -157,6 +159,7 @@ bool KCubicInterpolationPotentialMapVTK::GetValue(const string& array, const KPo
                                                   double* aValue) const
 {
     vtkDataArray* data = fImageData->GetPointData()->GetArray(array.c_str());
+    if (data == nullptr) return false;
 
     // get coordinates of surrounding mesh points
     static const char map[64][3] = {

--- a/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc
+++ b/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc
@@ -43,6 +43,7 @@ KMagfieldMapVTK::~KMagfieldMapVTK() {}
 bool KMagfieldMapVTK::GetValue(const string& array, const KPosition& aSamplePoint, double* aValue) const
 {
     vtkDataArray* data = fImageData->GetPointData()->GetArray(array.c_str());
+    if (data == nullptr) return false;
 
     // get coordinates of closest mesh point
     vtkIdType center = fImageData->FindPoint((double*) (aSamplePoint.Components()));
@@ -90,6 +91,7 @@ bool KLinearInterpolationMagfieldMapVTK::GetValue(const string& array, const KPo
                                                   double* aValue) const
 {
     vtkDataArray* data = fImageData->GetPointData()->GetArray(array.c_str());
+    if (data == nullptr) return false;
 
     // get coordinates of surrounding mesh points
     static const char map[8][3] = {
@@ -156,6 +158,7 @@ bool KCubicInterpolationMagfieldMapVTK::GetValue(const string& array, const KPos
                                                  double* aValue) const
 {
     vtkDataArray* data = fImageData->GetPointData()->GetArray(array.c_str());
+    if (data == nullptr) return false;
 
     // get coordinates of surrounding mesh points
     static const char map[64][3] = {


### PR DESCRIPTION
When only a magnetic field grid is available, no gradient of the field, Kassiopeia crashes hard due to a null pointer `data`, see e.g. below. This bugfix adds a `return false` when `data` is a nullptr. In that case, a proper warning inside Kassiopeia is given:
```
[KEMFIELD NORMAL MESSAGE] WARNING: could not compute magnetic gradient at sample point 
<KPosition>
    <0>(double)-1.85045e-05<\0>
    <1>(double)0.0971891<\1>
    <2>(double)1.1351<\2>
<\KPosition>
```

Original crash backtrace:
```
[KSMAIN NORMAL MESSAGE] ☻   welcome to Kassiopeia 3.7.4  ☻ 
****[KSRUN NORMAL MESSAGE] processing run 0 ...
********[KSEVENT NORMAL MESSAGE] processing event 0 <generator_proton_along_positive_z_decay> ...
************[KSTRACK NORMAL MESSAGE] processing track 0 <generator_proton_along_positive_z_decay> ...
****************[KSSTEP NORMAL MESSAGE] processing step 0 ... (z = 0.5, r = 0, k = 800, e = 800)
 *** Break *** segmentation violation

===========================================================
There was a crash.
This is the entire stack trace of all threads:
===========================================================
#0  0x00007fa787f0664a in __GI___wait4 (pid=2383889, stat_loc=stat_loc
entry=0x7fffd9af28b8, options=options
entry=0, usage=usage
entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#1  0x00007fa787f0660b in __GI___waitpid (pid=<optimized out>, stat_loc=stat_loc
entry=0x7fffd9af28b8, options=options
entry=0) at waitpid.c:38
#2  0x00007fa787e78017 in do_system (line=<optimized out>) at ../sysdeps/posix/system.c:172
#3  0x00007fa789a99fb1 in TUnixSystem::Exec(char const*) (shellcmd=<optimized out>, this=0x55c477775f00) at /usr/local/src/cmake_root/root-6.22.06/core/unix/src/TUnixSystem.cxx:2117
#4  TUnixSystem::StackTrace() (this=0x55c477775f00) at /usr/local/src/cmake_root/root-6.22.06/core/unix/src/TUnixSystem.cxx:2408
#5  0x00007fa789a97335 in TUnixSystem::DispatchSignals(ESignals) (this=0x55c477775f00, sig=kSigSegmentationViolation) at /usr/local/src/cmake_root/root-6.22.06/core/unix/src/TUnixSystem.cxx:3646
#6  0x00007fa788222bb0 in <signal handler called> () at /lib/x86_64-linux-gnu/libpthread.so.0
#7  0x00007fa7932028d6 in vtkAbstractArray::GetNumberOfComponents() (this=0x0) at /usr/include/vtk-7.1/vtkAbstractArray.h:127
#8  0x00007fa79320936b in KEMField::KLinearInterpolationMagfieldMapVTK::GetValue(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, KEMField::KThreeVector_<true> const&, double*) const (this=0x55c47d
efaca0, array="magnetic gradient", aSamplePoint=..., aValue=0x7fffd9af56a0) at /home/wdconinc/git/Kassiopeia/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc:124
#9  0x00007fa793208de8 in KEMField::KMagfieldMapVTK::GetGradient(KEMField::KThreeVector_<true> const&, double const&, KEMField::KGradient&) const (this=0x55c47defaca0, aSamplePoint=..., aGradient=...) at /home/wdconinc/git/Kassiopeia/KE
MField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc:76
#10 0x00007fa79320a675 in KEMField::KMagnetostaticFieldmap::MagneticGradientCore(KEMField::KThreeVector_<true> const&) const (this=0x55c47c0077c0, P=...) at /home/wdconinc/git/Kassiopeia/KEMField/Source/Plugins/VTKPart2/src/KMagnetostat
icFieldmap.cc:338
#11 0x00007fa7934d011a in KEMField::KMagnetostaticField::MagneticGradientCore(KEMField::KThreeVector_<true> const&, double const&) const (this=0x55c47c0077c0, P=...) at /home/wdconinc/git/Kassiopeia/KEMField/Source/Interface/Fields/Magn
etic/include/KMagnetostaticField.hh:57
```