### PR TITLE
Enhancement: [cmake] default to CMAKE_CXX_STANDARD=14 but allow override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(VTK QUIET)
 
 set( BUILD_SHARED_LIBS ON )
 
-set( CMAKE_CXX_STANDARD 14 )
+set( CMAKE_CXX_STANDARD 14 CACHE STRING "The C++ standard whose features are requested to build this target" )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 set( CMAKE_CXX_EXTENSIONS OFF )
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )


### PR DESCRIPTION
When Kassiopeia is linked against ROOT, the [same C++ standard must be used](https://root.cern/install/build_from_source/#setting-the-c-standard), i.e. linking against ROOT compiled with C++17 requires compiling Kassiopeia with `CMAKE_CXX_STANDARD=17`. This becomes more and more relevant as other frameworks start to rely on ROOT compiled with C++17. Linking Kassiopeia against C++17 is an advantage as it would otherwise require a parallel ROOT installation. Kassiopeia linked against ROOT compiled with C++17 works just fine as it is; no changes needed.

However, currently specifying `-DCMAKE_CXX_STANDARD=17` on the cmake command line does not take any effect, because of the `set(CMAKE_CXX_STANDARD=14)` line. By modifying that line to set a [cache entry](https://cmake.org/cmake/help/latest/command/set.html#set-cache-entry), the user can override the C++ standard (at their own risk), but the default value is used if nothing is specified. This is the approach ROOT itself uses to default to C++11 but allow overrides.

Possible suggestion for future consideration: Since the C++ standard that ROOT was compiled with, it may make sense to 'inherit' that standard in Kassiopeia when `KASPER_USE_ROOT=ON`. I couldn't figure out how to make that work, though. ROOT's cmake scripts do not expose the info, and `root-config` only contains it in the `--cflags` output if the C++ standard is not the default of the compiler.