### PR TITLE
Bugfix: new save_magfield3 should respect directory in same element

### DIFF
--- a/KEMField/Source/Bindings/Fields/Magnetic/include/KStaticElectromagnetFieldBuilder.hh
+++ b/KEMField/Source/Bindings/Fields/Magnetic/include/KStaticElectromagnetFieldBuilder.hh
@@ -39,6 +39,10 @@ template<> inline bool KStaticElectromagnetFieldBuilder::AddAttribute(KContainer
         aContainer->CopyTo(fObject, &KEMField::KGStaticElectromagnetField::SetSaveMagfield3);
         return true;
     }
+    if (aContainer->GetName() == "directory_magfield3") {
+        aContainer->CopyTo(fObject, &KEMField::KGStaticElectromagnetField::SetDirectoryMagfield3);
+        return true;
+    }
     if (aContainer->GetName() == "surfaces") {
         std::vector<KGeoBag::KGSurface*> tSurfaces =
             KGeoBag::KGInterface::GetInstance()->RetrieveSurfaces(aContainer->AsString());

--- a/KEMField/Source/Bindings/Fields/Magnetic/src/KStaticElectromagnetFieldBuilder.cc
+++ b/KEMField/Source/Bindings/Fields/Magnetic/src/KStaticElectromagnetFieldBuilder.cc
@@ -21,6 +21,7 @@ STATICINT sKStaticElectromagnetFieldStructure = KStaticElectromagnetFieldBuilder
                                                 KStaticElectromagnetFieldBuilder::Attribute<std::string>("file") +
                                                 KStaticElectromagnetFieldBuilder::Attribute<std::string>("directory") +
                                                 KStaticElectromagnetFieldBuilder::Attribute<bool>("save_magfield3") +
+                                                KStaticElectromagnetFieldBuilder::Attribute<std::string>("directory_magfield3") +
                                                 KStaticElectromagnetFieldBuilder::Attribute<std::string>("system") +
                                                 KStaticElectromagnetFieldBuilder::Attribute<std::string>("surfaces") +
                                                 KStaticElectromagnetFieldBuilder::Attribute<std::string>("spaces");

--- a/KEMField/Source/Interface/Fields/Magnetic/include/KStaticElectromagnetField.hh
+++ b/KEMField/Source/Interface/Fields/Magnetic/include/KStaticElectromagnetField.hh
@@ -22,7 +22,10 @@ class KStaticElectromagnetField : public KMagnetostaticField
     ~KStaticElectromagnetField() override;
 
     void SetDirectory(const std::string& aDirectory);
+    std::string GetDirectory() const;
+
     void SetFile(const std::string& aFile);
+    std::string GetFile() const;
 
     void SetFieldSolver(const KSmartPointer<KMagneticFieldSolver>& solver);
     KSmartPointer<KMagneticFieldSolver> GetFieldSolver();

--- a/KEMField/Source/Interface/Fields/Magnetic/src/KStaticElectromagnetField.cc
+++ b/KEMField/Source/Interface/Fields/Magnetic/src/KStaticElectromagnetField.cc
@@ -49,9 +49,19 @@ void KStaticElectromagnetField::SetDirectory(const std::string& aDirectory)
     fDirectory = aDirectory;
 }
 
+std::string KStaticElectromagnetField::GetDirectory() const
+{
+    return fDirectory;
+}
+
 void KStaticElectromagnetField::SetFile(const std::string& aFile)
 {
     fFile = aFile;
+}
+
+std::string KStaticElectromagnetField::GetFile() const
+{
+    return fFile;
 }
 
 void KStaticElectromagnetField::SetFieldSolver(const KSmartPointer<KMagneticFieldSolver>& solver)

--- a/KEMField/Source/Interface/KGeoBag/include/KGElectromagnetConverter.hh
+++ b/KEMField/Source/Interface/KGeoBag/include/KGElectromagnetConverter.hh
@@ -33,7 +33,7 @@ class KGElectromagnetConverter :
         return;
     }
 
-    void SetDumpMagfield3ToFile(const std::string& aFileName);
+    void SetDumpMagfield3ToFile(const std::string& aDirectory, const std::string& aFileName);
 
   protected:
     KEMField::KElectromagnetContainer* fElectromagnetContainer;

--- a/KEMField/Source/Interface/KGeoBag/include/KGStaticElectromagnetField.hh
+++ b/KEMField/Source/Interface/KGeoBag/include/KGStaticElectromagnetField.hh
@@ -29,6 +29,7 @@ class KGStaticElectromagnetField : public KStaticElectromagnetField
     void AddSpace(KGeoBag::KGSpace* aSpace);
 
     void SetSaveMagfield3(bool aFlag);
+    void SetDirectoryMagfield3(const std::string& aDirectory);
 
     KSmartPointer<KGeoBag::KGElectromagnetConverter> GetConverter();
 
@@ -48,6 +49,7 @@ class KGStaticElectromagnetField : public KStaticElectromagnetField
     KSmartPointer<KGeoBag::KGElectromagnetConverter> fConverter;
 
     bool fSaveMagfield3;
+    std::string fDirectoryMagfield3;
 };
 
 } /* namespace KEMField */

--- a/KEMField/Source/Interface/KGeoBag/src/KGElectromagnetConverter.cc
+++ b/KEMField/Source/Interface/KGeoBag/src/KGElectromagnetConverter.cc
@@ -31,9 +31,9 @@ KGElectromagnetConverter::~KGElectromagnetConverter()
         fMagfield3File->Close();
 }
 
-void KGElectromagnetConverter::SetDumpMagfield3ToFile(const std::string& aFileName)
+void KGElectromagnetConverter::SetDumpMagfield3ToFile(const std::string& aDirectory, const std::string& aFileName)
 {
-    fMagfield3File = katrin::KTextFile::CreateOutputTextFile(aFileName);
+    fMagfield3File = katrin::KTextFile::CreateOutputTextFile(aDirectory, aFileName);
     if (!fMagfield3File)
         return;
 

--- a/KEMField/Source/Interface/KGeoBag/src/KGElectromagnetConverter.cc
+++ b/KEMField/Source/Interface/KGeoBag/src/KGElectromagnetConverter.cc
@@ -27,7 +27,7 @@ KGElectromagnetConverter::KGElectromagnetConverter() :
 {}
 KGElectromagnetConverter::~KGElectromagnetConverter()
 {
-    if (fMagfield3File)
+    if (fMagfield3File && fMagfield3File->IsOpen())
         fMagfield3File->Close();
 }
 
@@ -231,7 +231,7 @@ void KGElectromagnetConverter::VisitCylinderTubeSpace(KGCylinderTubeSpace* cylin
                                               GlobalToInternalVector(fCurrentZAxis));
         fElectromagnetContainer->push_back(coil);
 
-        if (fMagfield3File->IsOpen()) {
+        if (fMagfield3File && fMagfield3File->IsOpen()) {
             auto* tStream = fMagfield3File->File();
 
             // do not use coil->GetP0|P1() because it is defined as (r,0,z)

--- a/KEMField/Source/Interface/KGeoBag/src/KGElectromagnetConverter.cc
+++ b/KEMField/Source/Interface/KGeoBag/src/KGElectromagnetConverter.cc
@@ -38,6 +38,11 @@ void KGElectromagnetConverter::SetDumpMagfield3ToFile(const std::string& aDirect
         return;
 
     fMagfield3File->Open(katrin::KFile::eWrite);
+    if (!fMagfield3File->IsOpen()) {
+        kem_cout(eWarning) << "magfield3 file could not be opened" << eom;
+        return;
+    }
+
     kem_cout() << "Saving magfield3 geometry to file: " << fMagfield3File->GetName() << eom;
 
     auto* tStream = fMagfield3File->File();
@@ -226,7 +231,7 @@ void KGElectromagnetConverter::VisitCylinderTubeSpace(KGCylinderTubeSpace* cylin
                                               GlobalToInternalVector(fCurrentZAxis));
         fElectromagnetContainer->push_back(coil);
 
-        if (fMagfield3File) {
+        if (fMagfield3File->IsOpen()) {
             auto* tStream = fMagfield3File->File();
 
             // do not use coil->GetP0|P1() because it is defined as (r,0,z)

--- a/KEMField/Source/Interface/KGeoBag/src/KGStaticElectromagnetField.cc
+++ b/KEMField/Source/Interface/KGeoBag/src/KGStaticElectromagnetField.cc
@@ -81,7 +81,7 @@ void KGStaticElectromagnetField::ConfigureSurfaceContainer()
 
     if (fSaveMagfield3) {
         string tFileName = GetName() + string(".mag3");
-        GetConverter()->SetDumpMagfield3ToFile(tFileName);
+        GetConverter()->SetDumpMagfield3ToFile(GetDirectory(), tFileName);
     }
 
     if (fSystem != nullptr) {

--- a/KEMField/Source/Interface/KGeoBag/src/KGStaticElectromagnetField.cc
+++ b/KEMField/Source/Interface/KGeoBag/src/KGStaticElectromagnetField.cc
@@ -15,7 +15,12 @@ using namespace std;
 namespace KEMField
 {
 
-KGStaticElectromagnetField::KGStaticElectromagnetField() : fSystem(nullptr), fConverter(nullptr) {}
+KGStaticElectromagnetField::KGStaticElectromagnetField() :
+    fSystem(nullptr),
+    fConverter(nullptr),
+    fSaveMagfield3(true),
+    fDirectoryMagfield3(SCRATCH_DEFAULT_DIR)
+{}
 
 KGStaticElectromagnetField::~KGStaticElectromagnetField() = default;
 
@@ -37,6 +42,11 @@ void KGStaticElectromagnetField::AddSpace(KGeoBag::KGSpace* aSpace)
 void KGStaticElectromagnetField::SetSaveMagfield3(bool aFlag)
 {
     fSaveMagfield3 = aFlag;
+}
+
+void KGStaticElectromagnetField::SetDirectoryMagfield3(const string& aDirectory)
+{
+    fDirectoryMagfield3 = aDirectory;
 }
 
 KSmartPointer<KGeoBag::KGElectromagnetConverter> KGStaticElectromagnetField::GetConverter()
@@ -81,7 +91,7 @@ void KGStaticElectromagnetField::ConfigureSurfaceContainer()
 
     if (fSaveMagfield3) {
         string tFileName = GetName() + string(".mag3");
-        GetConverter()->SetDumpMagfield3ToFile(GetDirectory(), tFileName);
+        GetConverter()->SetDumpMagfield3ToFile(fDirectoryMagfield3, tFileName);
     }
 
     if (fSystem != nullptr) {


### PR DESCRIPTION
In configurations such as
```xml
<electromagnet_field
    name="magnetic_field_electromagnet"
    directory="[KEMFIELD_CACHE]"
    save_magfield3="true"
    file="ProtonTrapMagnets.kbd"
    system="world/proton_trap"
    spaces="world/proton_trap/@magnet_tag"
>
```
the mag3 files are not saved in the directory immediately above. This is counter-intuitive, but even worse when using docker or singularity containers it defaults to a non-writable location. This also affects some examples, such as DipoleTrapSimulation.xml.

This pull request introduces a public getter for the directory (and file) of the underlying `KStaticElectromagnetField` which is then used by `KGStaticElectromagnetField` to instruct `KGElectromagnetConverter` to write to the directory location.

This pull request also ensures that failure to open the file for writing is flagged as a warning but does not cause Kassiopeia to shut down with a stack trace.