### PR TITLE
Feature: ROOT track painter arbitrary plane defined by point and normal

### DIFF
--- a/Kassiopeia/Bindings/Visualization/Include/KSROOTTrackPainterBuilder.h
+++ b/Kassiopeia/Bindings/Visualization/Include/KSROOTTrackPainterBuilder.h
@@ -29,6 +29,22 @@ template<> inline bool KSROOTTrackPainterBuilder::AddAttribute(KContainer* aCont
         aContainer->CopyTo(fObject, &KSROOTTrackPainter::SetPath);
         return true;
     }
+    if (aContainer->GetName() == "plane_normal") {
+        aContainer->CopyTo(fObject, &KSROOTTrackPainter::SetPlaneNormal);
+        return true;
+    }
+    if (aContainer->GetName() == "plane_point") {
+        aContainer->CopyTo(fObject, &KSROOTTrackPainter::SetPlanePoint);
+        return true;
+    }
+    if (aContainer->GetName() == "swap_axis") {
+        aContainer->CopyTo(fObject, &KSROOTTrackPainter::SetSwapAxis);
+        return true;
+    }
+    if (aContainer->GetName() == "epsilon") {
+        aContainer->CopyTo(fObject, &KSROOTTrackPainter::SetEpsilon);
+        return true;
+    }
     if (aContainer->GetName() == "x_axis") {
         aContainer->CopyTo(fObject, &KSROOTTrackPainter::SetXAxis);
         return true;

--- a/Kassiopeia/Bindings/Visualization/Source/KSROOTTrackPainterBuilder.cxx
+++ b/Kassiopeia/Bindings/Visualization/Source/KSROOTTrackPainterBuilder.cxx
@@ -15,6 +15,10 @@ STATICINT sKSROOTTrackPainterStructure = KSROOTTrackPainterBuilder::Attribute<st
                                          KSROOTTrackPainterBuilder::Attribute<std::string>("base") +
                                          KSROOTTrackPainterBuilder::Attribute<std::string>("x_axis") +
                                          KSROOTTrackPainterBuilder::Attribute<std::string>("y_axis") +
+                                         KSROOTTrackPainterBuilder::Attribute<KThreeVector>("plane_normal") +
+                                         KSROOTTrackPainterBuilder::Attribute<KThreeVector>("plane_point") +
+                                         KSROOTTrackPainterBuilder::Attribute<bool>("swap_axis") +
+                                         KSROOTTrackPainterBuilder::Attribute<double>("epsilon") +
                                          KSROOTTrackPainterBuilder::Attribute<std::string>("step_output_group_name") +
                                          KSROOTTrackPainterBuilder::Attribute<std::string>("position_name") +
                                          KSROOTTrackPainterBuilder::Attribute<std::string>("track_output_group_name") +

--- a/Kassiopeia/Visualization/Include/KSROOTTrackPainter.h
+++ b/Kassiopeia/Visualization/Include/KSROOTTrackPainter.h
@@ -35,6 +35,13 @@ class KSROOTTrackPainter : public katrin::KROOTPainter
     std::string GetXAxisLabel() override;
     std::string GetYAxisLabel() override;
 
+  private:
+    std::string GetAxisLabel(KThreeVector anAxis);
+
+  public:
+    void CalculatePlaneCoordinateSystem();
+    void TransformToPlaneSystem(const KThreeVector aPoint, KTwoVector& aPlanePoint);
+
     void AddBaseColor(TColor aColor, double aFraction);
 
     typedef enum  // NOLINT(modernize-use-using)

--- a/Kassiopeia/Visualization/Include/KSROOTTrackPainter.h
+++ b/Kassiopeia/Visualization/Include/KSROOTTrackPainter.h
@@ -1,6 +1,11 @@
 #ifndef _Kassiopeia_KSROOTTrackPainter_h_
 #define _Kassiopeia_KSROOTTrackPainter_h_
 
+#include "KThreeVector.hh"
+#include "KTwoVector.hh"
+using KGeoBag::KThreeVector;
+using KGeoBag::KTwoVector;
+
 #include "KField.h"
 #include "KROOTPainter.h"
 #include "KROOTWindow.h"
@@ -60,6 +65,18 @@ class KSROOTTrackPainter : public katrin::KROOTPainter
     K_SET(std::string, Path);
     ;
     K_SET(std::string, Base);
+    ;
+    K_SET(KThreeVector, PlaneNormal);
+    ;
+    K_SET(KThreeVector, PlanePoint);
+    ;
+    K_SET(bool, SwapAxis);
+    ;
+    K_GET(KThreeVector, PlaneVectorA);
+    ;
+    K_GET(KThreeVector, PlaneVectorB);
+    ;
+    K_SET(double, Epsilon);
     ;
     K_SET(std::string, XAxis);
     ;

--- a/Kassiopeia/Visualization/Source/KSROOTTrackPainter.cxx
+++ b/Kassiopeia/Visualization/Source/KSROOTTrackPainter.cxx
@@ -17,6 +17,12 @@ namespace Kassiopeia
 KSROOTTrackPainter::KSROOTTrackPainter() :
     fPath(""),
     fBase(""),
+    fPlaneNormal(0.0, 1.0, 0.0),
+    fPlanePoint(0.0, 0.0, 0.0),
+    fSwapAxis(false),
+    fPlaneVectorA(0.0, 0.0, 1.0),
+    fPlaneVectorB(1.0, 0.0, 0.0),
+    fEpsilon(1.0e-10),
     fXAxis("z"),
     fYAxis("y"),
     fStepOutputGroupName("output_step_world"),


### PR DESCRIPTION
`root_geometry_painter` already had an option to project on an arbitrary plane, defined by point and normal. E.g.
```xml
<root_window
    name="root_window_xy"
    canvas_width="1024"
    canvas_height="1024"
    write_enabled="false"
    path="[output_path]"
>
    <root_geometry_painter
        name="root_geometry_painter_xy"
        surfaces="world/proton_trap/#"
        plane_normal="0 {sin(18.*[deg])} {cos(18.*[deg])}"
        plane_point="{[detector_x]} {[detector_y]} {[detector_z]}"
        swap_axis="false"
    />
</root_window>
```
However, this was not possible for the `root_track_painter`, not for `plot_mode="track"` nor for `plot_mode="step"`.

This commits adds support for the same syntax to the ROOT track painter, while (of course) keeping backwards compatibility. This will now require specifying axes `a` and `b`. E.g.
```xml
    <root_track_painter
        name="root_track_painter_xy"
        path="[output_path]"
        base="ProtonTrapSimulation.root"
        plane_normal="0 {sin(18.*[deg])} {cos(18.*[deg])}"
        plane_point="{[detector_x]} {[detector_y]} {[detector_z]}"
        swap_axis="false"
        x_axis="a"
        y_axis="b"
        plot_mode="track"
        track_output_group_name="component_track_world"
        step_output_group_name="component_step_world"
        position_name="final_position"
        color_mode="track"
        color_variable="final_kinetic_energy"
        color_palette="default"
        draw_options="*"
        axial_mirror="false"
    />
```

This is particularly useful (in our experience) when combined with geometry to get a quick look at detector elements that are tilted with respect to the primary cartesian coordinate system. Here is an example that shows the projection of the track end points onto the angled proton detector on the right side:
![image](https://user-images.githubusercontent.com/4656391/105617686-d20d3500-5da5-11eb-9f0b-6cea5ca15b10.png)

Because the ROOT geometry painter is implemented in KGeoBag and the ROOT track painter in Kassiopeia, there is duplication of code for two functions. Because there is no joint base class, I could not see an immediate way to avoid it. A refactoring would likely be needed to avoid this.