### PR TITLE
Feature: fieldmap superposition with position check and requirement options

### DIFF
--- a/KEMField/Source/Bindings/Fields/Magnetic/include/KMagneticSuperpositionFieldBuilder.hh
+++ b/KEMField/Source/Bindings/Fields/Magnetic/include/KMagneticSuperpositionFieldBuilder.hh
@@ -49,6 +49,9 @@ template<> inline bool KMagneticSuperpositionFieldBuilder::AddAttribute(KContain
     else if (aContainer->GetName() == "use_caching") {
         aContainer->CopyTo(fObject, &KEMField::KMagneticSuperpositionField::SetUseCaching);
     }
+    else if (aContainer->GetName() == "require") {
+        aContainer->CopyTo(fObject, &KEMField::KMagneticSuperpositionField::SetRequire);
+    }
     else
         return false;
     return true;

--- a/KEMField/Source/Bindings/Fields/Magnetic/include/KMagnetostaticFieldmapBuilder.hh
+++ b/KEMField/Source/Bindings/Fields/Magnetic/include/KMagnetostaticFieldmapBuilder.hh
@@ -42,6 +42,10 @@ template<> inline bool KMagnetostaticFieldmapBuilder::AddAttribute(KContainer* a
         aContainer->CopyTo(fObject, &KEMField::KMagnetostaticFieldmap::SetInterpolation);
         return true;
     }
+    if (aContainer->GetName() == "magnetic_gradient_numerical") {
+        aContainer->CopyTo(fObject, &KEMField::KMagnetostaticFieldmap::SetGradNumerical);
+        return true;
+    }
     return false;
 }
 

--- a/KEMField/Source/Bindings/Fields/Magnetic/src/KMagneticSuperpositionFieldBuilder.cc
+++ b/KEMField/Source/Bindings/Fields/Magnetic/src/KMagneticSuperpositionFieldBuilder.cc
@@ -23,6 +23,7 @@ STATICINT sKMagneticSuperpositionFieldEntryStructure =
 STATICINT sKMagneticSuperpositionFieldStructure =
     KMagneticSuperpositionFieldBuilder::Attribute<std::string>("name") +
     KMagneticSuperpositionFieldBuilder::Attribute<bool>("use_caching") +
+    KMagneticSuperpositionFieldBuilder::Attribute<std::string>("require") +
     KMagneticSuperpositionFieldBuilder::ComplexElement<KMagneticSuperpositionFieldEntry>("add_field");
 
 

--- a/KEMField/Source/Bindings/Fields/Magnetic/src/KMagnetostaticFieldmapBuilder.cc
+++ b/KEMField/Source/Bindings/Fields/Magnetic/src/KMagnetostaticFieldmapBuilder.cc
@@ -21,7 +21,8 @@ template<> KMagnetostaticFieldmapBuilder::~KComplexElement() = default;
 STATICINT sKMagnetostaticFieldmapStructure = KMagnetostaticFieldmapBuilder::Attribute<std::string>("name") +
                                              KMagnetostaticFieldmapBuilder::Attribute<std::string>("directory") +
                                              KMagnetostaticFieldmapBuilder::Attribute<std::string>("file") +
-                                             KMagnetostaticFieldmapBuilder::Attribute<std::string>("interpolation");
+                                             KMagnetostaticFieldmapBuilder::Attribute<std::string>("interpolation") +
+                                             KMagnetostaticFieldmapBuilder::Attribute<bool>("magnetic_gradient_numerical");
 
 STATICINT sKMagnetostaticFieldmap = KEMToolboxBuilder::ComplexElement<KMagnetostaticFieldmap>("magnetic_fieldmap");
 

--- a/KEMField/Source/Interface/Fields/Magnetic/include/KMagneticField.hh
+++ b/KEMField/Source/Interface/Fields/Magnetic/include/KMagneticField.hh
@@ -45,6 +45,10 @@ class KMagneticField : public katrin::KNamed
         return MagneticFieldAndGradientCore(P, time);
     }
 
+    virtual bool Check(const KPosition& P, const double& time) const
+    {
+        return CheckCore(P, time);
+    }
 
     void Initialize()
     {
@@ -70,6 +74,12 @@ class KMagneticField : public katrin::KNamed
         KGradient grad = MagneticGradientCore(P, time);
 
         return std::pair<KFieldVector, KGradient>(field, grad);
+    }
+
+    virtual bool CheckCore(const KPosition& /*P*/, const double& /*time*/) const
+    {
+        //default behavior is to assume all points are valid
+        return true;
     }
 
     virtual void InitializeCore() {}

--- a/KEMField/Source/Interface/Fields/Magnetic/include/KMagneticSuperpositionField.hh
+++ b/KEMField/Source/Interface/Fields/Magnetic/include/KMagneticSuperpositionField.hh
@@ -36,6 +36,16 @@ class KMagneticSuperpositionField : public KMagneticField
         fUseCaching = useCaching;
     }
 
+    void SetRequire(const std::string& require)
+    {
+        if (require == "all") fRequireAll = true;
+        else fRequireAll = false;
+        if (require == "one") fRequireOne = true;
+        else fRequireOne = false;
+        if (require == "any") fRequireAny = true;
+        else fRequireAny = false;
+    }
+
   private:
     void InitializeCore() override;
 
@@ -55,6 +65,9 @@ class KMagneticSuperpositionField : public KMagneticField
 
     bool fUseCaching;
     bool fCachingBlock;
+    bool fRequireAll;
+    bool fRequireOne;
+    bool fRequireAny;
     mutable std::map<KPosition, std::vector<KFieldVector>> fPotentialCache;
     mutable std::map<KPosition, std::vector<KFieldVector>> fFieldCache;
     mutable std::map<KPosition, std::vector<KGradient>> fGradientCache;

--- a/KEMField/Source/Interface/Fields/Magnetic/include/KMagneticSuperpositionField.hh
+++ b/KEMField/Source/Interface/Fields/Magnetic/include/KMagneticSuperpositionField.hh
@@ -22,6 +22,8 @@ class KMagneticSuperpositionField : public KMagneticField
     KMagneticSuperpositionField();
     ~KMagneticSuperpositionField() override;
 
+    bool CheckCore(const KPosition& aSamplePoint, const double& aSampleTime) const override;
+
     KFieldVector MagneticPotentialCore(const KPosition& aSamplePoint, const double& aSampleTime) const override;
     KFieldVector MagneticFieldCore(const KPosition& aSamplePoint, const double& aSampleTime) const override;
     KGradient MagneticGradientCore(const KPosition& aSamplePoint, const double& aSampleTime) const override;

--- a/KEMField/Source/Interface/Fields/Magnetic/include/KMagneticSuperpositionField.hh
+++ b/KEMField/Source/Interface/Fields/Magnetic/include/KMagneticSuperpositionField.hh
@@ -19,6 +19,15 @@ namespace KEMField
 class KMagneticSuperpositionField : public KMagneticField
 {
   public:
+    enum RequirementType
+    {
+        rtNone, // no requirements on fields
+        rtAll,  // require all fields to be valid
+        rtAny,  // require one or more fields to be valid
+        rtOne   // require exactly one field to be valid
+    };
+
+  public:
     KMagneticSuperpositionField();
     ~KMagneticSuperpositionField() override;
 
@@ -38,15 +47,7 @@ class KMagneticSuperpositionField : public KMagneticField
         fUseCaching = useCaching;
     }
 
-    void SetRequire(const std::string& require)
-    {
-        if (require == "all") fRequireAll = true;
-        else fRequireAll = false;
-        if (require == "one") fRequireOne = true;
-        else fRequireOne = false;
-        if (require == "any") fRequireAny = true;
-        else fRequireAny = false;
-    }
+    void SetRequire(const std::string& require);
 
   private:
     void InitializeCore() override;
@@ -67,9 +68,7 @@ class KMagneticSuperpositionField : public KMagneticField
 
     bool fUseCaching;
     bool fCachingBlock;
-    bool fRequireAll;
-    bool fRequireOne;
-    bool fRequireAny;
+    RequirementType fRequire;
     mutable std::map<KPosition, std::vector<KFieldVector>> fPotentialCache;
     mutable std::map<KPosition, std::vector<KFieldVector>> fFieldCache;
     mutable std::map<KPosition, std::vector<KGradient>> fGradientCache;

--- a/KEMField/Source/Interface/Fields/Magnetic/include/KMagnetostaticField.hh
+++ b/KEMField/Source/Interface/Fields/Magnetic/include/KMagnetostaticField.hh
@@ -41,6 +41,11 @@ class KMagnetostaticField : public KMagneticField
         return MagneticGradientCore(P);
     }
 
+    bool Check(const KPosition& P) const
+    {
+        return CheckCore(P);
+    }
+
   private:
     KFieldVector MagneticPotentialCore(const KPosition& P, const double& /*time*/) const override
     {
@@ -63,6 +68,11 @@ class KMagnetostaticField : public KMagneticField
         return MagneticFieldAndGradientCore(P);
     }
 
+    bool CheckCore(const KPosition& P, const double& /*time*/) const override
+    {
+        return CheckCore(P);
+    }
+
     virtual KFieldVector MagneticPotentialCore(const KPosition& P) const = 0;
     virtual KFieldVector MagneticFieldCore(const KPosition& P) const = 0;
     virtual KGradient MagneticGradientCore(const KPosition& P) const = 0;
@@ -74,6 +84,11 @@ class KMagnetostaticField : public KMagneticField
         KGradient grad = MagneticGradientCore(P);
 
         return std::pair<KFieldVector, KGradient>(field, grad);
+    }
+    virtual bool CheckCore(const KPosition& /*P*/) const
+    {
+        //default behavior is to assume all points are valid
+        return true;
     }
 };
 }  // namespace KEMField

--- a/KEMField/Source/Interface/Fields/Magnetic/src/KMagneticSuperpositionField.cc
+++ b/KEMField/Source/Interface/Fields/Magnetic/src/KMagneticSuperpositionField.cc
@@ -15,7 +15,10 @@ using namespace std;
 namespace KEMField
 {
 
-KMagneticSuperpositionField::KMagneticSuperpositionField() : fUseCaching(false), fCachingBlock(false) {}
+KMagneticSuperpositionField::KMagneticSuperpositionField() : fUseCaching(false), fCachingBlock(false)
+{
+  SetRequire("all");
+}
 
 KMagneticSuperpositionField::~KMagneticSuperpositionField() = default;
 
@@ -89,11 +92,26 @@ KFieldVector KMagneticSuperpositionField::CalculateCachedField(const KPosition& 
     //Calculating Fields without Enhancement for aSamplePoint and insert it into the cache
     vector<KFieldVector> tFields;
     KFieldVector tCurrentField;
+    bool check_all = true;
+    bool check_any = false;
+    bool check_one = false;
     for (size_t tIndex = 0; tIndex < fMagneticFields.size(); tIndex++) {
+        if (! fMagneticFields.at(tIndex)->Check(aSamplePoint, aSampleTime)) {
+            check_all = false;
+            continue;
+        }
         tCurrentField = fMagneticFields.at(tIndex)->MagneticField(aSamplePoint, aSampleTime);
         aField += tCurrentField * fEnhancements.at(tIndex);
         tFields.push_back(tCurrentField);
+        check_one = ! check_one && ! check_any;
+        check_any = true;
     }
+    if (fRequireAll && ! check_all)
+        kem_cout(eWarning) << "MagneticField not available: at least one field not available at point" << eom;
+    if (fRequireAny && ! check_any)
+        kem_cout(eWarning) << "MagneticField not available: not any fields available at point" << eom;
+    if (fRequireOne && ! check_one)
+        kem_cout(eWarning) << "MagneticField not available: not exactly one field available at point" << eom;
     fFieldCache.insert(make_pair(aSamplePoint, tFields));
     return aField;
 }
@@ -114,11 +132,26 @@ KGradient KMagneticSuperpositionField::CalculateCachedGradient(const KPosition& 
     //Calculating Fields without Enhancement for aSamplePoint and insert it into the cache
     vector<KGradient> tGradients;
     KGradient tCurrentGradient;
+    bool check_all = true;
+    bool check_any = false;
+    bool check_one = false;
     for (size_t tIndex = 0; tIndex < fMagneticFields.size(); tIndex++) {
+        if (! fMagneticFields.at(tIndex)->Check(aSamplePoint, aSampleTime)) {
+            check_all = false;
+            continue;
+        }
         tCurrentGradient = fMagneticFields.at(tIndex)->MagneticGradient(aSamplePoint, aSampleTime);
         aGradient += tCurrentGradient * fEnhancements.at(tIndex);
         tGradients.push_back(tCurrentGradient);
+        check_one = ! check_one && ! check_any;
+        check_any = true;
     }
+    if (fRequireAll && ! check_all)
+        kem_cout(eWarning) << "MagneticField not available: at least one field not available at point" << eom;
+    if (fRequireAny && ! check_any)
+        kem_cout(eWarning) << "MagneticField not available: not any fields available at point" << eom;
+    if (fRequireOne && ! check_one)
+        kem_cout(eWarning) << "MagneticField not available: not exactly one field available at point" << eom;
     fGradientCache.insert(make_pair(aSamplePoint, tGradients));
     return aGradient;
 }

--- a/KEMField/Source/Plugins/VTKPart2/include/KMagnetostaticFieldmap.hh
+++ b/KEMField/Source/Plugins/VTKPart2/include/KMagnetostaticFieldmap.hh
@@ -146,9 +146,12 @@ class KMagfieldMapVTK
     virtual ~KMagfieldMapVTK();
 
   protected:
+    virtual bool CheckValue(const std::string& array, const KPosition& aSamplePoint) const;
     virtual bool GetValue(const std::string& array, const KPosition& aSamplePoint, double* aValue) const;
 
   public:
+    virtual bool CheckField(const KPosition& aSamplePoint, const double& aSampleTime) const;
+    virtual bool CheckGradient(const KPosition& aSamplePoint, const double& aSampleTime) const;
     virtual bool GetField(const KPosition& aSamplePoint, const double& aSampleTime, KFieldVector& aField) const;
     virtual bool GetGradient(const KPosition& aSamplePoint, const double& aSampleTime, KGradient& aGradient) const;
 
@@ -198,6 +201,7 @@ class KMagnetostaticFieldmap : public KMagnetostaticField
     KFieldVector MagneticPotentialCore(const KPosition& P) const override;
     KFieldVector MagneticFieldCore(const KPosition& P) const override;
     KGradient MagneticGradientCore(const KPosition& P) const override;
+    bool CheckCore(const KPosition& P) const;
     void InitializeCore() override;
 
   private:

--- a/KEMField/Source/Plugins/VTKPart2/include/KMagnetostaticFieldmap.hh
+++ b/KEMField/Source/Plugins/VTKPart2/include/KMagnetostaticFieldmap.hh
@@ -196,6 +196,7 @@ class KMagnetostaticFieldmap : public KMagnetostaticField
     void SetDirectory(const std::string& aDirectory);
     void SetFile(const std::string& aFile);
     void SetInterpolation(const std::string& aMode);
+    void SetGradNumerical(bool aFlag);
 
   private:
     KFieldVector MagneticPotentialCore(const KPosition& P) const override;
@@ -208,6 +209,7 @@ class KMagnetostaticFieldmap : public KMagnetostaticField
     std::string fDirectory;
     std::string fFile;
     int fInterpolation;
+    bool fGradNumerical;
     std::shared_ptr<KMagfieldMapVTK> fFieldMap;
 };
 

--- a/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc
+++ b/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc
@@ -47,12 +47,17 @@ bool KMagfieldMapVTK::CheckValue(const string& array, const KPosition& aSamplePo
     vtkDataArray* data = fImageData->GetPointData()->GetArray(array.c_str());
     if (data == nullptr) return false;
 
-    // get coordinates of closest mesh point
-    vtkIdType center = fImageData->FindPoint((double*) (aSamplePoint.Components()));
-    if (center < 0)
+    // get bounds of data set (FindPoint returns nearest point even outside bounds)
+    double bounds[6];
+    fImageData->GetBounds(bounds);
+    if (aSamplePoint.X() < bounds[0] || aSamplePoint.X() > bounds[1])
         return false;
-    else
-        return true;
+    if (aSamplePoint.Y() < bounds[2] || aSamplePoint.Y() > bounds[3])
+        return false;
+    if (aSamplePoint.Z() < bounds[4] || aSamplePoint.Z() > bounds[5])
+        return false;
+
+    return true;
 }
 
 bool KMagfieldMapVTK::GetValue(const string& array, const KPosition& aSamplePoint, double* aValue) const

--- a/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc
+++ b/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc
@@ -334,6 +334,7 @@ double KCubicInterpolationMagfieldMapVTK::_tricubicInterpolate(double p[], doubl
 KMagnetostaticFieldmap::KMagnetostaticFieldmap() :
     fDirectory(SCRATCH_DEFAULT_DIR),
     fInterpolation(0),
+    fGradNumerical(false),
     fFieldMap(nullptr)
 {}
 
@@ -392,10 +393,16 @@ void KMagnetostaticFieldmap::SetInterpolation(const string& aMode)
     return;
 }
 
+void KMagnetostaticFieldmap::SetGradNumerical(bool aFlag)
+{
+    fGradNumerical = aFlag;
+}
+
 bool KMagnetostaticFieldmap::CheckCore(const KPosition& P) const
 {
     double aRandomTime = 0;
-    return fFieldMap->CheckField(P, aRandomTime) && fFieldMap->CheckGradient(P, aRandomTime);
+    return fFieldMap->CheckField(P, aRandomTime) &&
+          (fFieldMap->CheckGradient(P, aRandomTime) || fGradNumerical);
 }
 
 void KMagnetostaticFieldmap::InitializeCore()


### PR DESCRIPTION
This implements a solution to #39 to allow magnetic field superpositions that occupy different regions in space. A use case is to stitch together _N_ magnetic field maps without complaining about missing field values in _N-1_ of the maps for every point.

This introduces `magnetic_field_superposition` syntax such as:
```xml
<magnetic_superposition_field
  name="magnetic_field_electromagnet"
  use_caching="true"
  require="one"
>
```
where `require` can take values `all` (default, previous behavior), `any` (i.e. at least one), `one` (i.e. exactly one), or `none` (i.e. don't care even if no values are present). Technically, `none` could be any other value.

This also introduces `magnetic_fieldmap` syntax such as:
```xml
<magnetic_fieldmap
  name="magnetic_field_electromagnet_0-80"
  directory="./maps/Cryogenic"
  file="Z0-80med_output.vti"
  interpolation="linear"
  magnetic_gradient_numerical="true"
/>
```
where `magnetic_gradient_numerical` is a boolean which defaults to false (previous behavior). This tells the fieldmap routines to ignore missing magnetic gradients. The actual numerical field gradient calculating will be in a separate PR.

### Implementation
As suggested in #39, this introduces a new `KMagneticField::Check()` (and virtual `KMagneticField::CheckCore()`). By default `CheckCore` takes both position and time, and by default it simply returns true (i.e. field is valid everywhere anytime).

In `KMagnetostaticField`, the `Check` and `CheckCore` functions are reimplemented to only take position arguments, an by default this return true (i.e. field is valid everywhere).

`CheckCore` is overriden in `KMagneticSuperpositionField` to do actual checking of each of the underlying fields, depending on the `require` setting. In `MagneticFieldCore` and `MagneticGradientCore` we now start with a `CheckCore` call which solely serves to produce warnings. Then, in both the cached and direct calculations of the superposition field, all available fields are added (as before), but for fields that are not available no attempt is made to retrieve the field (this avoids the warnings when retrieving the field for points outside of the bounds of the magnetic field maps).

`CheckCore` is overriden in `KMagnetostaticFieldmap` to do actual checking of the field and gradient (if the gradient is not calculated numerically per the `magnetic_gradient_numerical` setting).

Finally, in `KMagfieldMapVTK` the check is implemented by getting the fieldmap bounds from the VTK fieldmap.

### Limitations
Since we use the fieldmap boundaries to decide on validity, this is strictly speaking too strict for `nearest` and too loose for `cubic` interpolations. Fieldmaps that are stitched together perfectly (e.g. boundary points are in two neighboring fieldmaps), this will still result in the cubic interpolations failing for points in the outer layers inside the bounds.

### Additional work possible
Currently it is the responsibility of individual field classes to call `Check` (on other classes) or `CheckCore` (on themselves, when called from `MagneticFieldCore` and `MagneticGradientCore`). It should be possible, I imagine, to move this up further into the internals of Kassiopeia, maybe in the Trajectories and/or Operators. However, I think that's probably more trouble than is gained.

`kem_cout(eWarning)` doesn't seem to like it when KThreeVectors are streamed into it directly, so I used `.XYZ()` getters.