### PR TITLE
Bugfix: Gradient plotting requires dividing by |B|, not multiplying

### DIFF
--- a/Kassiopeia/Visualization/Source/KSROOTMagFieldPainter.cxx
+++ b/Kassiopeia/Visualization/Source/KSROOTMagFieldPainter.cxx
@@ -135,7 +135,7 @@ void KSROOTMagFieldPainter::FieldMapZ(KSMagneticField* tMagField, double tDeltaZ
                                     tMagneticField.Z() * tGradient[5]);
                         tGradB.SetZ(tMagneticField.X() * tGradient[6] + tMagneticField.Y() * tGradient[7] +
                                     tMagneticField.Z() * tGradient[8]);
-                        tGradB *= tMagneticField.Magnitude();
+                        tGradB /= tMagneticField.Magnitude();
                         if (fPlot == "magnetic_gradient_abs") {
                             Map->SetBinContent(i + 1, fRsteps - j + 1, tGradB.Magnitude());
                             Map->SetBinContent(i + 1, fRsteps + j + 1, tGradB.Magnitude());
@@ -275,7 +275,7 @@ void KSROOTMagFieldPainter::FieldMapZ(KSMagneticField* tMagField, double tDeltaZ
                                     tMagneticField.Z() * tGradient[5]);
                         tGradB.SetZ(tMagneticField.X() * tGradient[6] + tMagneticField.Y() * tGradient[7] +
                                     tMagneticField.Z() * tGradient[8]);
-                        tGradB *= tMagneticField.Magnitude();
+                        tGradB /= tMagneticField.Magnitude();
                         if (fPlot == "magnetic_gradient_abs") {
                             Map->SetBinContent(i + 1, fRsteps + j + 1, tGradB.Magnitude());
                         }

--- a/Kassiopeia/Visualization/Source/KSROOTMagFieldPainter.cxx
+++ b/Kassiopeia/Visualization/Source/KSROOTMagFieldPainter.cxx
@@ -135,7 +135,8 @@ void KSROOTMagFieldPainter::FieldMapZ(KSMagneticField* tMagField, double tDeltaZ
                                     tMagneticField.Z() * tGradient[5]);
                         tGradB.SetZ(tMagneticField.X() * tGradient[6] + tMagneticField.Y() * tGradient[7] +
                                     tMagneticField.Z() * tGradient[8]);
-                        tGradB /= tMagneticField.Magnitude();
+                        if (tMagneticField.Magnitude() > 0)
+                            tGradB /= tMagneticField.Magnitude();
                         if (fPlot == "magnetic_gradient_abs") {
                             Map->SetBinContent(i + 1, fRsteps - j + 1, tGradB.Magnitude());
                             Map->SetBinContent(i + 1, fRsteps + j + 1, tGradB.Magnitude());
@@ -275,7 +276,8 @@ void KSROOTMagFieldPainter::FieldMapZ(KSMagneticField* tMagField, double tDeltaZ
                                     tMagneticField.Z() * tGradient[5]);
                         tGradB.SetZ(tMagneticField.X() * tGradient[6] + tMagneticField.Y() * tGradient[7] +
                                     tMagneticField.Z() * tGradient[8]);
-                        tGradB /= tMagneticField.Magnitude();
+                        if (tMagneticField.Magnitude() > 0)
+                            tGradB /= tMagneticField.Magnitude();
                         if (fPlot == "magnetic_gradient_abs") {
                             Map->SetBinContent(i + 1, fRsteps + j + 1, tGradB.Magnitude());
                         }


### PR DESCRIPTION
In `<root_magfield_painter>` visualizations, `tGradB` is set to B·∇B, but is not normalized by |B|. This normalizes the quantity property. Now `magnetic_gradient_numerical="false"` and `magnetic_gradient_numerical="true"` give the same result.