### PR TITLE
TestField.cxx needs VTK: build if KEMField_USE_VTK

### DIFF
--- a/Kassiopeia/Applications/Validation/CMakeLists.txt
+++ b/Kassiopeia/Applications/Validation/CMakeLists.txt
@@ -3,7 +3,6 @@ if (Kassiopeia_ENABLE_APP)
 
     # executables
     set( VALIDATION_SOURCE_BASENAMES
-        TestField
         # TestTrajectory
         # TestGenerator
         # TestSpaceInteraction
@@ -26,6 +25,7 @@ if (Kassiopeia_ENABLE_APP)
     if(Kassiopeia_USE_VTK)
         if(KEMField_USE_VTK)
             list( APPEND VALIDATION_SOURCE_BASENAMES
+                TestField
                 TestPotentialmap
             )
         endif(KEMField_USE_VTK)


### PR DESCRIPTION
Without this bugfix, builds on systems without VTK fail.

Ref: https://github.com/KATRIN-Experiment/Kassiopeia/blob/v3.8.0/Kassiopeia/Applications/Validation/Source/TestField.cxx#L4