### PR TITLE
Minor fixes for VTK 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(KASPER_VERSION "${KASPER_VERSION_MAJOR}.${KASPER_VERSION_MINOR}.${KASPER_VER
 #project( Kasper )
 project( Kasper VERSION ${KASPER_VERSION}
                 DESCRIPTION "The KATRIN Analysis and Simulations Package"
-                LANGUAGES CXX )
+                LANGUAGES CXX C )
 
 set( BUILD_SHARED_LIBS ON )
 set( Boost_USE_STATIC_LIBS OFF )

--- a/KGeoBag/Source/Visualization/Vtk/Source/KGVTKGeometryPainter.cc
+++ b/KGeoBag/Source/Visualization/Vtk/Source/KGVTKGeometryPainter.cc
@@ -22,6 +22,7 @@
 #include "vtkSTLWriter.h"
 #include "vtkTriangleFilter.h"
 #include "vtkXMLPolyDataWriter.h"
+#include "vtkUnsignedCharArray.h"
 
 #include <cmath>
 


### PR DESCRIPTION
Two minor fixes to get Kassiopeia to compile against VTK 9 (9.0.3 in my case).
- vtkUnsignedCharArray is not automatically included through vtkPolyData anymore
- MPI C compiler (used in vtk) needs LANGUAGES C in Kassiopeia (https://gitlab.kitware.com/vtk/vtk/-/issues/17734)
