### PR TITLE
Add time functionality to KMagnetostaticFieldmapCalculator(Builder)

### DIFF
--- a/KEMField/Source/Bindings/Fields/Magnetic/include/KMagnetostaticFieldmapBuilder.hh
+++ b/KEMField/Source/Bindings/Fields/Magnetic/include/KMagnetostaticFieldmapBuilder.hh
@@ -105,6 +105,10 @@ template<> inline bool KMagnetostaticFieldmapCalculatorBuilder::AddAttribute(KCo
         aContainer->CopyTo(fObject, &KEMField::KMagnetostaticFieldmapCalculator::SetSpacing);
         return true;
     }
+    if (aContainer->GetName() == "time") {
+        aContainer->CopyTo(fObject, &KEMField::KMagnetostaticFieldmapCalculator::SetTime);
+        return true;
+    }
     if (aContainer->GetName() == "spaces") {
         std::vector<KGeoBag::KGSpace*> tSpaces =
             KGeoBag::KGInterface::GetInstance()->RetrieveSpaces(aContainer->AsString());
@@ -125,8 +129,8 @@ template<> inline bool KMagnetostaticFieldmapCalculatorBuilder::AddAttribute(KCo
     if (aContainer->GetName() == "field") {
         std::string fieldName;
         aContainer->CopyTo(fieldName);
-        KEMField::KMagnetostaticField* field =
-            katrin::KToolbox::GetInstance().Get<KEMField::KMagnetostaticField>(fieldName);
+        KEMField::KMagneticField* field =
+            katrin::KToolbox::GetInstance().Get<KEMField::KMagneticField>(fieldName);
         fObject->AddMagneticField(field);
         return true;
     }
@@ -135,7 +139,7 @@ template<> inline bool KMagnetostaticFieldmapCalculatorBuilder::AddAttribute(KCo
 
 template<> inline bool KMagnetostaticFieldmapCalculatorBuilder::AddElement(KContainer* aContainer)
 {
-    if (aContainer->Is<KEMField::KMagnetostaticField>()) {
+    if (aContainer->Is<KEMField::KMagneticField>()) {
         aContainer->ReleaseTo(fObject, &KEMField::KMagnetostaticFieldmapCalculator::AddMagneticField);
         return true;
     }

--- a/KEMField/Source/Bindings/Fields/Magnetic/src/KMagnetostaticFieldmapBuilder.cc
+++ b/KEMField/Source/Bindings/Fields/Magnetic/src/KMagnetostaticFieldmapBuilder.cc
@@ -42,6 +42,7 @@ STATICINT sKMagnetostaticFieldmapCalculatorStructure =
     KMagnetostaticFieldmapCalculatorBuilder::Attribute<bool>("mirror_y") +
     KMagnetostaticFieldmapCalculatorBuilder::Attribute<bool>("mirror_z") +
     KMagnetostaticFieldmapCalculatorBuilder::Attribute<double>("spacing") +
+    KMagnetostaticFieldmapCalculatorBuilder::Attribute<double>("time") +
     KMagnetostaticFieldmapCalculatorBuilder::Attribute<std::string>("spaces") +
     KMagnetostaticFieldmapCalculatorBuilder::Attribute<std::string>("field") +
     // support of deprecated old xml:

--- a/KEMField/Source/Plugins/VTKPart2/include/KMagnetostaticFieldmap.hh
+++ b/KEMField/Source/Plugins/VTKPart2/include/KMagnetostaticFieldmap.hh
@@ -270,7 +270,11 @@ class KMagnetostaticFieldmapCalculator
     {
         fSpacing = aSpacing;
     }
-    void AddMagneticField(KMagnetostaticField* aField)
+    void SetTime(double aTime)
+    {
+        fTime = aTime;
+    }
+    void AddMagneticField(KMagneticField* aField)
     {
         if (!aField)
             throw KEMSimpleException("cannot add invalid magnetic field");
@@ -325,7 +329,8 @@ class KMagnetostaticFieldmapCalculator
     KFieldVector fLength;
     bool fMirrorX, fMirrorY, fMirrorZ;
     double fSpacing;
-    std::map<std::string, KMagnetostaticField*> fMagneticFields;
+    double fTime;
+    std::map<std::string, KMagneticField*> fMagneticFields;
     std::vector<const KGeoBag::KGSpace*> fSpaces;
 
     vtkSmartPointer<vtkImageData> fGrid;

--- a/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc
+++ b/KEMField/Source/Plugins/VTKPart2/src/KMagnetostaticFieldmap.cc
@@ -516,7 +516,8 @@ KMagnetostaticFieldmapCalculator::KMagnetostaticFieldmapCalculator() :
     fMirrorX(false),
     fMirrorY(false),
     fMirrorZ(false),
-    fSpacing(1.)
+    fSpacing(1.),
+    fTime(0.)
 {}
 
 KMagnetostaticFieldmapCalculator::~KMagnetostaticFieldmapCalculator() = default;
@@ -712,7 +713,7 @@ void KMagnetostaticFieldmapCalculator::Execute()
             tField = KFieldVector::sZero;
             try {
                 for (auto& it : fMagneticFields)
-                    tField += it.second->MagneticField(KPosition(tPoint));
+                    tField += it.second->MagneticField(KPosition(tPoint), fTime);
             }
             catch (katrin::KGslException& e) {
                 tField = KFieldVector::sInvalid;
@@ -783,7 +784,7 @@ void KMagnetostaticFieldmapCalculator::Execute()
                     /// FIXME: summing up gradients from multiple fields doesn't make much sense,
                     /// Needs to be handled in a better way, e.g. calculate gradient from field map directly.
                     for (auto& it : fMagneticFields)
-                        tGradient += it.second->MagneticGradient(KPosition(tPoint));
+                        tGradient += it.second->MagneticGradient(KPosition(tPoint), fTime);
                 }
                 catch (katrin::KGslException& e) {
                     tGradient = KThreeMatrix::sInvalid;


### PR DESCRIPTION
In response to issue #57 .

I added a time parameter to KMagnetostaticFieldmapCalculator(Builder) and changed the type from fMagneticField to KMagnetostaticField to KMagneticField. This allows to calculate fieldmaps also for non-static fields by giving an evaluation time. The default evaluation time is 0. 

The KMagnetostaticFieldmap is not changed as the stored field does not have time dependence stored and thus is still a KMagnetostaticField.

The code compiles without any problems. The code was tested by calculating and exporting a fieldmap from a KMagneticSuperpositionField (which is a KMagneticField but not a KMagnetostaticField). Inspection of the created VTI file shows the expected behaviour.