### PR TITLE
Avoid use inputwire after fclose

### DIFF
--- a/KEMField/Source/Plugins/Root/src/KEMRootFieldCanvas.cc
+++ b/KEMField/Source/Plugins/Root/src/KEMRootFieldCanvas.cc
@@ -177,8 +177,6 @@ void KEMRootFieldCanvas::DrawGeomRZ(const std::string& conicSectfile, const std:
                 }
             }
         }
-
-        fclose(inputwire);
     }
 
     // Read in magnet coils


### PR DESCRIPTION
This avoids the 'use after fclose' error where `fclose(inputwire)` is already unconditionally handled before the `fclose(inputwire)` removed in this PR.