### PR TITLE
Avoid std::iterator for c++17, use member types

### DIFF
--- a/KEMField/Source/Surfaces/include/KSurfaceContainer.hh
+++ b/KEMField/Source/Surfaces/include/KSurfaceContainer.hh
@@ -52,13 +52,24 @@ class KSurfaceContainer
 * @author T.J. Corona
 */
 
+#if __cplusplus >= 201703L
     class iterator : public std::iterator<std::bidirectional_iterator_tag, KSurfacePrimitive*>
+#else
+    class iterator
+#endif
     {
       public:
+#if __cplusplus >= 201703L
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = KSurfacePrimitive*;
+        using reference = value_type&;
+        using pointer = value_type*;
+#else
         using iterator_category = std::bidirectional_iterator_tag;
         using value_type = std::iterator<std::bidirectional_iterator_tag, KSurfacePrimitive*>::value_type;
         using reference = std::iterator<std::bidirectional_iterator_tag, KSurfacePrimitive*>::reference;
         using pointer = std::iterator<std::bidirectional_iterator_tag, KSurfacePrimitive*>::pointer;
+#endif
 
         friend class KSurfaceContainer;
 


### PR DESCRIPTION
This addresses #60 by using the member type based inference for iterator types in c++17 provided by gcc 12.1.0 on ubuntu 22.04.

I did not make any of the following changes, which may be useful to consider:
- There are no limits on the allowed c++ standards that can be set at cmake. Something like the following may be useful: 
```cmake
if(NOT CMAKE_CXX_STANDARD MATCHES "14|17|20")
  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
endif()
```