### PR TITLE
Draft: Kommon: Bake KConst epoch into header file

### DIFF
--- a/Kommon/Base/CMakeLists.txt
+++ b/Kommon/Base/CMakeLists.txt
@@ -41,8 +41,8 @@ set(KOMMON_BASE_HEADER_FILES
     Utility/KAlgorithm.h
     Utility/KException.h
     Utility/KCast.h
-    Utility/KConst.h
     Utility/KConst_2006.h
+    Utility/KConst_2021.h
     Utility/KConsoleMuter.h
     Utility/KHash.h
     Utility/OstreamJoiner.h
@@ -193,8 +193,10 @@ elseif(KConst_REFERENCE_EPOCH LESS 2021)
     "of some calculations. To restore *default* behavior, set KConst_REFERENCE_EPOCH=2021.")
 endif()
 
-# Needed for physical constants defined in Utility/KConst.h
-target_compile_definitions(KommonBase PUBLIC KConst_REFERENCE_EPOCH=${KConst_REFERENCE_EPOCH})
+# Bake KConst_REFERENCE_EPOCH into KConst.h
+configure_file( Utility/KConst.h.in ${CMAKE_CURRENT_BINARY_DIR}/Utility/KConst.h @ONLY )
+list( APPEND KOMMON_BASE_HEADER_FILES ${CMAKE_CURRENT_BINARY_DIR}/Utility/KConst.h )
+target_include_directories( KommonBase PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/Utility> )
 
 kasper_install_libraries( KommonBase )
 kasper_install_headers( ${KOMMON_BASE_HEADER_FILES} )

--- a/Kommon/Base/Utility/KConst.h.in
+++ b/Kommon/Base/Utility/KConst.h.in
@@ -1,0 +1,10 @@
+#if @KConst_REFERENCE_EPOCH@ == 2006
+#include "KConst_2006.h"
+
+#elif @KConst_REFERENCE_EPOCH@ == 2021
+#include "KConst_2021.h"
+
+#else
+#error "Unsupported value for KConst_REFERENCE_EPOCH."
+
+#endif

--- a/Kommon/Base/Utility/KConst_2021.h
+++ b/Kommon/Base/Utility/KConst_2021.h
@@ -7,11 +7,6 @@
  * @author S. Hickford <stephanie.hickford@kit.edu>
  */
 
-#if KConst_REFERENCE_EPOCH == 2006
-#include "KConst_2006.h"
-
-#elif KConst_REFERENCE_EPOCH == 2021
-
 #ifndef KCONST_H_
 #define KCONST_H_
 
@@ -457,7 +452,3 @@ constexpr double Ue3sq()
 } /* namespace katrin */
 
 #endif  //KCONST_H
-
-#else
-#error "Unsupported value for KConst_REFERENCE_EPOCH."
-#endif


### PR DESCRIPTION
When using Kassiopeia as an external library, as described in #72 there were compilation issues observed, likely because of missing definition of the rerefence epoch. This commit fixes that by ensuring the corresponding compile-time constant to be baked into the corresponding header file.

Btw. an alternative approach would maybe include adding this variable to the `KommonConfig.cmake` file via `add_definitions`, which however is less portable since that requires others to use the CMake build system to get the correct variables.

Closes #72.

@pslocum Could you test if this indeed fixes your issue?