### PR TITLE
Convert warning to info message when adding additional controls/terms to trajectory

### DIFF
--- a/Kassiopeia/Trajectories/Source/KSTrajTrajectoryAdiabatic.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajTrajectoryAdiabatic.cxx
@@ -95,8 +95,8 @@ void KSTrajTrajectoryAdiabatic::ClearInterpolator(KSTrajAdiabaticInterpolator* a
 void KSTrajTrajectoryAdiabatic::AddTerm(KSTrajAdiabaticDifferentiator* aTerm)
 {
     if (fTerms.FindElementByType(aTerm) != -1) {
-        trajmsg(eWarning) << "adding term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
-                          << "> to already existing term of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fTerms.AddElement(aTerm) != -1) {
         return;
@@ -118,8 +118,8 @@ void KSTrajTrajectoryAdiabatic::RemoveTerm(KSTrajAdiabaticDifferentiator* aTerm)
 void KSTrajTrajectoryAdiabatic::AddControl(KSTrajAdiabaticControl* aControl)
 {
     if (fControls.FindElementByType(aControl) != -1) {
-        trajmsg(eWarning) << "adding control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
-                          << "> to already existing control of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fControls.AddElement(aControl) != -1) {
         return;

--- a/Kassiopeia/Trajectories/Source/KSTrajTrajectoryAdiabaticSpin.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajTrajectoryAdiabaticSpin.cxx
@@ -92,8 +92,8 @@ void KSTrajTrajectoryAdiabaticSpin::ClearInterpolator(KSTrajAdiabaticSpinInterpo
 void KSTrajTrajectoryAdiabaticSpin::AddTerm(KSTrajAdiabaticSpinDifferentiator* aTerm)
 {
     if (fTerms.FindElementByType(aTerm) != -1) {
-        trajmsg(eWarning) << "adding term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
-                          << "> to already existing term of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fTerms.AddElement(aTerm) != -1) {
         return;
@@ -115,8 +115,8 @@ void KSTrajTrajectoryAdiabaticSpin::RemoveTerm(KSTrajAdiabaticSpinDifferentiator
 void KSTrajTrajectoryAdiabaticSpin::AddControl(KSTrajAdiabaticSpinControl* aControl)
 {
     if (fControls.FindElementByType(aControl) != -1) {
-        trajmsg(eWarning) << "adding control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
-                          << "> to already existing control of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fControls.AddElement(aControl) != -1) {
         return;

--- a/Kassiopeia/Trajectories/Source/KSTrajTrajectoryElectric.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajTrajectoryElectric.cxx
@@ -91,8 +91,8 @@ void KSTrajTrajectoryElectric::ClearInterpolator(KSTrajElectricInterpolator* anI
 void KSTrajTrajectoryElectric::AddTerm(KSTrajElectricDifferentiator* aTerm)
 {
     if (fTerms.FindElementByType(aTerm) != -1) {
-        trajmsg(eWarning) << "adding term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
-                          << "> to already existing term of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fTerms.AddElement(aTerm) != -1) {
         return;
@@ -115,8 +115,8 @@ void KSTrajTrajectoryElectric::RemoveTerm(KSTrajElectricDifferentiator* aTerm)
 void KSTrajTrajectoryElectric::AddControl(KSTrajElectricControl* aControl)
 {
     if (fControls.FindElementByType(aControl) != -1) {
-        trajmsg(eWarning) << "adding control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
-                          << "> to already existing control of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fControls.AddElement(aControl) != -1) {
         return;

--- a/Kassiopeia/Trajectories/Source/KSTrajTrajectoryExact.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajTrajectoryExact.cxx
@@ -92,8 +92,8 @@ void KSTrajTrajectoryExact::ClearInterpolator(KSTrajExactInterpolator* anInterpo
 void KSTrajTrajectoryExact::AddTerm(KSTrajExactDifferentiator* aTerm)
 {
     if (fTerms.FindElementByType(aTerm) != -1) {
-        trajmsg(eWarning) << "adding term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
-                          << "> to already existing term of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fTerms.AddElement(aTerm) != -1) {
         return;
@@ -115,8 +115,8 @@ void KSTrajTrajectoryExact::RemoveTerm(KSTrajExactDifferentiator* aTerm)
 void KSTrajTrajectoryExact::AddControl(KSTrajExactControl* aControl)
 {
     if (fControls.FindElementByType(aControl) != -1) {
-        trajmsg(eWarning) << "adding control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
-                          << "> to already existing control of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fControls.AddElement(aControl) != -1) {
         return;

--- a/Kassiopeia/Trajectories/Source/KSTrajTrajectoryExactSpin.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajTrajectoryExactSpin.cxx
@@ -92,8 +92,8 @@ void KSTrajTrajectoryExactSpin::ClearInterpolator(KSTrajExactSpinInterpolator* a
 void KSTrajTrajectoryExactSpin::AddTerm(KSTrajExactSpinDifferentiator* aTerm)
 {
     if (fTerms.FindElementByType(aTerm) != -1) {
-        trajmsg(eWarning) << "adding term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
-                          << "> to already existing term of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fTerms.AddElement(aTerm) != -1) {
         return;
@@ -115,8 +115,8 @@ void KSTrajTrajectoryExactSpin::RemoveTerm(KSTrajExactSpinDifferentiator* aTerm)
 void KSTrajTrajectoryExactSpin::AddControl(KSTrajExactSpinControl* aControl)
 {
     if (fControls.FindElementByType(aControl) != -1) {
-        trajmsg(eWarning) << "adding control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
-                          << "> to already existing control of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fControls.AddElement(aControl) != -1) {
         return;

--- a/Kassiopeia/Trajectories/Source/KSTrajTrajectoryExactTrapped.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajTrajectoryExactTrapped.cxx
@@ -92,8 +92,8 @@ void KSTrajTrajectoryExactTrapped::ClearInterpolator(KSTrajExactTrappedInterpola
 void KSTrajTrajectoryExactTrapped::AddTerm(KSTrajExactTrappedDifferentiator* aTerm)
 {
     if (fTerms.FindElementByType(aTerm) != -1) {
-        trajmsg(eWarning) << "adding term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
-                          << "> to already existing term of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fTerms.AddElement(aTerm) != -1) {
         return;
@@ -115,8 +115,8 @@ void KSTrajTrajectoryExactTrapped::RemoveTerm(KSTrajExactTrappedDifferentiator* 
 void KSTrajTrajectoryExactTrapped::AddControl(KSTrajExactTrappedControl* aControl)
 {
     if (fControls.FindElementByType(aControl) != -1) {
-        trajmsg(eWarning) << "adding control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
-                          << "> to already existing control of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fControls.AddElement(aControl) != -1) {
         return;

--- a/Kassiopeia/Trajectories/Source/KSTrajTrajectoryMagnetic.cxx
+++ b/Kassiopeia/Trajectories/Source/KSTrajTrajectoryMagnetic.cxx
@@ -91,8 +91,8 @@ void KSTrajTrajectoryMagnetic::ClearInterpolator(KSTrajMagneticInterpolator* anI
 void KSTrajTrajectoryMagnetic::AddTerm(KSTrajMagneticDifferentiator* aTerm)
 {
     if (fTerms.FindElementByType(aTerm) != -1) {
-        trajmsg(eWarning) << "adding term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
-                          << "> to already existing term of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional term <" << dynamic_cast<katrin::KNamed*>(aTerm)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fTerms.AddElement(aTerm) != -1) {
         return;
@@ -114,8 +114,8 @@ void KSTrajTrajectoryMagnetic::RemoveTerm(KSTrajMagneticDifferentiator* aTerm)
 void KSTrajTrajectoryMagnetic::AddControl(KSTrajMagneticControl* aControl)
 {
     if (fControls.FindElementByType(aControl) != -1) {
-        trajmsg(eWarning) << "adding control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
-                          << "> to already existing control of same type in <" << this->GetName() << ">" << eom;
+        trajmsg(eInfo) << "adding additional control <" << dynamic_cast<katrin::KNamed*>(aControl)->GetName()
+                          << "> to <" << this->GetName() << ">" << eom;
     }
     if (fControls.AddElement(aControl) != -1) {
         return;


### PR DESCRIPTION
The message to be changed was introduced to warn the user in the special case when terms/controls of the same type are added twice (e.g. when a term_propagation is added to a trajectory with a term_propagation). This can lead to unwanted behavior. However, with the current implementation the user is warned even when a term/control of different type is added to the trajectory. As the ability to add multiple different terms/controls to the trajectory is an intended feature of Kassiopeia, this warning message created confusion when the feature is used correctly. 

This change, therefore, converts the warning message to an info message, which only states that an additional term/control is added to the trajectory. This should eliminate confusion while maintaining the level of information needed to troubleshoot the simulation. 


Thanks to @pslocum for bringing up this topic! 