### PR TITLE
Fix Scattering Terminators

### DIFF
--- a/Kassiopeia/Terminators/Include/KSTermOutput.h
+++ b/Kassiopeia/Terminators/Include/KSTermOutput.h
@@ -42,6 +42,7 @@ template<class XValueType> class KSTermOutput : public KSComponentTemplate<KSTer
         }
 
         if (*fValue >= fMaxValue || *fValue <= fMinValue) {
+            *fValue = 0;
             aFlag = true;
             return;
         }


### PR DESCRIPTION
This commit resets the KSTermOutput terminator value when terminator is called. 

This bug was reported by a Kassiopeia user who tried to setup a simulation using 

```
<ksterm_output name="term_max_elastic" group="output_track_h2" component="track_n_h2_elastic" max_value="1"/>
<ksterm_output name="term_max_excitation" group="output_track_h2" component="track_n_h2_excitation" max_value="1"/>
<ksterm_output name="term_max_ionisation" group="output_track_h2" component="track_n_h2_ionisation" max_value="1"/>
``` 
 He observed that after the first termination of this kind, all following tracks were terminated after one step with the same terminator. 