### PR TITLE
KSComponentMath: Fix segfault during destruction

### DIFF
--- a/Kassiopeia/Objects/Include/KSComponentMath.h
+++ b/Kassiopeia/Objects/Include/KSComponentMath.h
@@ -56,7 +56,19 @@ template<class XValueType> class KSComponentMath : public KSComponent
         fFunction = new TF1("(anonymous)", fTerm.c_str(), -1., 1.);
     }
     KSComponentMath(const KSComponentMath<XValueType>& aCopy) :
-        KSComponentMath(aCopy.fParentComponents, aCopy.fParents, aCopy.fTerm) {}
+        KSComponent(aCopy),
+        fParentComponents(aCopy.fParentComponents),
+        fParents(aCopy.fParents),
+        fResult(aCopy.fResult),
+        fTerm(aCopy.fTerm),
+        fFunction(aCopy.fFunction)
+    {
+        Set(&fResult);
+        this->SetParent(aCopy.fParentComponent);
+        for (size_t tIndex = 0; tIndex < aCopy.fParentComponents.size(); tIndex++) {
+            aCopy.fParentComponents.at(tIndex)->AddChild(this);
+        }
+    }
     ~KSComponentMath() override = default;
 
     //***********

--- a/Kassiopeia/Objects/Include/KSComponentMath.h
+++ b/Kassiopeia/Objects/Include/KSComponentMath.h
@@ -52,22 +52,11 @@ template<class XValueType> class KSComponentMath : public KSComponent
         }
 
         // initialize function once, parameters are updated every PushUpdate call
-        fFunction = std::make_shared<TF1>("(anonymous)", fTerm.c_str(), -1., 1.);
+        // Object is automatically managed and garbage collected by the global TROOT object (gROOT)
+        fFunction = new TF1("(anonymous)", fTerm.c_str(), -1., 1.);
     }
     KSComponentMath(const KSComponentMath<XValueType>& aCopy) :
-        KSComponent(aCopy),
-        fParentComponents(aCopy.fParentComponents),
-        fParents(aCopy.fParents),
-        fResult(aCopy.fResult),
-        fTerm(aCopy.fTerm),
-        fFunction(aCopy.fFunction)
-    {
-        Set(&fResult);
-        this->SetParent(aCopy.fParentComponent);
-        for (size_t tIndex = 0; tIndex < aCopy.fParentComponents.size(); tIndex++) {
-            aCopy.fParentComponents.at(tIndex)->AddChild(this);
-        }
-    }
+        KSComponentMath(aCopy.fParentComponents, aCopy.fParents, aCopy.fTerm) {}
     ~KSComponentMath() override = default;
 
     //***********
@@ -136,7 +125,7 @@ template<class XValueType> class KSComponentMath : public KSComponent
     std::vector<XValueType*> fParents;
     XValueType fResult;
     std::string fTerm;
-    std::shared_ptr<TF1> fFunction;
+    TF1* fFunction;
 };
 
 }  // namespace Kassiopeia


### PR DESCRIPTION
https://root.cern.ch/doc/master/classTROOT.html manages and deletes all ROOT objects, among which are also `TF1` objects created by `KSComponentMath`. So far, they were also deleted by `KSComponentMath`, causing in a segmentation fault.

There are two options:
 * Removing the object from `TROOT`
 * Not deleting the object in `KSComponentMath`

This commit goes for the latter. Note that while the general mechanics was already tested, this concrete code change was done in the GitHub Web IDE and therefore may contain typos, so one should just merge it after the CI finishes the tests.

Btw. it would be awesome to have Unit tests for `KSComponent`s (i.e. for everything that is a Kassiopeia `output`), but it seems to be a bit complex to set them up. Maybe that's an interesting challenge for later.