### PR TITLE
CI: Fix GitHub pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -16,6 +16,9 @@ jobs:
         python -m venv .venv
         source .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
+    
+    - name: Workaround for issue in m2d2 (https://github.com/CrossNox/m2r2/issues/68)
+      run: pip install "docutils>=0.18.1,<0.21"
 
     - name: Install dependencies
       run: pip install sphinx_rtd_theme sphinx_design m2r2 sphinx-simplepdf 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -10,6 +10,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    # Needed due to PEP 668 to install local packages
+    - name: Create and activate virtual Python environment
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
+
     - name: Install dependencies
       run: pip install sphinx_rtd_theme sphinx_design m2r2 sphinx-simplepdf 
     


### PR DESCRIPTION
Due to PEP 668, the recommended way to nowadays install Python software via `pip` is by creating a virtual environment. There are alternatives, but they are not recommended. Since this is required for our CI to work, this pull request adds a simple virtual environment.