### PR TITLE
KSWriteASCII: Fix header & improve output

### DIFF
--- a/Kassiopeia/Writers/Include/KSWriteASCII.h
+++ b/Kassiopeia/Writers/Include/KSWriteASCII.h
@@ -16,18 +16,18 @@ class KSWriteASCII : public KSComponentTemplate<KSWriteASCII, KSWriter>
     class Data
     {
       public:
-        Data(KSComponent* aComponent, KSWriteASCII* aWriter);
+        Data(KSComponent* aComponent, int aPrecision);
         ~Data();
 
+        void Initialize(KSComponent* aComponent, int aPrecision);
         void Start(const unsigned int& anIndex);
         std::string ValuesAsString();
-        void MakeTitle(KSComponent* aComponent, int aTrack);
+        std::string Label();
 
 
       private:
         std::string fLabel;
         std::string fType;
-        KSWriteASCII* fWriter;
         unsigned int fIndex;
         unsigned int fLength;
 
@@ -67,10 +67,11 @@ class KSWriteASCII : public KSComponentTemplate<KSWriteASCII, KSWriter>
 
     katrin::KTextFile* TextFile();
     void Write(std::string str);
+    void Write(char c);
     int Precision() const;
 
   protected:
-    katrin::KTextFile* MakeOutputFile(int anIndex) const;
+    void MakeOutputFile(int anIndex);
 
   private:
     std::string fBase;
@@ -163,18 +164,31 @@ inline void KSWriteASCII::SetPrecision(const unsigned int& aValue)
 
 inline katrin::KTextFile* KSWriteASCII::TextFile()
 {
+    if (!fTextFile)
+        MakeOutputFile(fTrackIndex);
+    
     return fTextFile;
 }
     
 inline void KSWriteASCII::Write(std::string str)
 {
     for (char& it : str)
-        fTextFile->File()->put(it);
+        TextFile()->File()->put(it);
+}
+    
+inline void KSWriteASCII::Write(char c)
+{
+    TextFile()->File()->put(c);
 }
 
 inline int KSWriteASCII::Precision() const
 {
     return fPrecision;
+}
+    
+inline std::string KSWriteASCII::Data::Label()
+{
+    return fLabel;
 }
 
 }  // namespace Kassiopeia

--- a/Kassiopeia/Writers/Include/KSWriteASCII.h
+++ b/Kassiopeia/Writers/Include/KSWriteASCII.h
@@ -31,7 +31,7 @@ class KSWriteASCII : public KSComponentTemplate<KSWriteASCII, KSWriter>
         unsigned int fIndex;
         unsigned int fLength;
 
-        class Objekt
+        class OutputObjectASCII
         {
           private:
             KSComponent* fComponent;
@@ -39,13 +39,13 @@ class KSWriteASCII : public KSComponentTemplate<KSWriteASCII, KSWriter>
             int fPrecision;
 
           public:
-            Objekt(KSComponent* aComponent, std::string aType, int Precision);
-            ~Objekt();
+            OutputObjectASCII(KSComponent* aComponent, std::string aType, int Precision);
+            ~OutputObjectASCII();
             std::string getValue();
         };
 
         std::vector<KSComponent*> fComponents;
-        std::vector<Objekt*> fObjekts;
+        std::vector<OutputObjectASCII*> fOutputObjectASCIIs;
     };
 
     using KSComponentMap = std::map<KSComponent*, Data*>;

--- a/Kassiopeia/Writers/Include/KSWriteASCII.h
+++ b/Kassiopeia/Writers/Include/KSWriteASCII.h
@@ -20,8 +20,9 @@ class KSWriteASCII : public KSComponentTemplate<KSWriteASCII, KSWriter>
         ~Data();
 
         void Start(const unsigned int& anIndex);
-        void Fill();
+        std::string ValuesAsString();
         void MakeTitle(KSComponent* aComponent, int aTrack);
+
 
       private:
         std::string fLabel;
@@ -65,6 +66,7 @@ class KSWriteASCII : public KSComponentTemplate<KSWriteASCII, KSWriter>
     void SetPrecision(const unsigned int& aValue);
 
     katrin::KTextFile* TextFile();
+    void Write(std::string str);
     int Precision() const;
 
   protected:
@@ -162,6 +164,12 @@ inline void KSWriteASCII::SetPrecision(const unsigned int& aValue)
 inline katrin::KTextFile* KSWriteASCII::TextFile()
 {
     return fTextFile;
+}
+    
+inline void KSWriteASCII::Write(std::string str)
+{
+    for (char& it : str)
+        fTextFile->File()->put(it);
 }
 
 inline int KSWriteASCII::Precision() const

--- a/Kassiopeia/Writers/Include/KSWriteASCII.h
+++ b/Kassiopeia/Writers/Include/KSWriteASCII.h
@@ -16,7 +16,6 @@ class KSWriteASCII : public KSComponentTemplate<KSWriteASCII, KSWriter>
     class Data
     {
       public:
-        Data(KSComponent* aComponent);
         Data(KSComponent* aComponent, KSWriteASCII* aWriter);
         ~Data();
 

--- a/Kassiopeia/Writers/Source/KSWriteASCII.cxx
+++ b/Kassiopeia/Writers/Source/KSWriteASCII.cxx
@@ -86,15 +86,14 @@ string KSWriteASCII::Data::OutputObjectASCII::getValue()
     return s.str();
 }
 
-KSWriteASCII::Data::Data(KSComponent* aComponent, KSWriteASCII* aWriter) :
+KSWriteASCII::Data::Data(KSComponent* aComponent, int aPrecision) :
     fLabel(""),
     fType(""),
     fIndex(0),
     fLength(0),
     fComponents()
 {
-    fWriter = aWriter;
-    MakeTitle(aComponent, 0);
+    Initialize(aComponent, aPrecision);
 }
 
 KSWriteASCII::Data::~Data() = default;
@@ -130,7 +129,7 @@ std::string KSWriteASCII::Data::ValuesAsString()
     return result;
 }
 
-void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
+void KSWriteASCII::Data::Initialize(KSComponent* aComponent, int aPrecision)
 {
     wtrmsg_debug("making title for object <" << aComponent->GetName() << ">" << eom);
 
@@ -138,7 +137,7 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
     if (tComponentGroup != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a group" << eom);
         for (unsigned int tIndex = 0; tIndex < tComponentGroup->ComponentCount(); tIndex++)
-            MakeTitle(tComponentGroup->ComponentAt(tIndex), aTrack);
+            Initialize(tComponentGroup->ComponentAt(tIndex), aPrecision);
 
         return;
     }
@@ -146,16 +145,11 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
     auto* tString = aComponent->As<string>();
     if (tString != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a string" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "string", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "string", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
 
         return;
     }
@@ -163,263 +157,201 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
     auto* tTwoVector = aComponent->As<KTwoVector>();
     if (tTwoVector != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a two_vector" << eom);
-        string str = (aComponent->GetName() + string("_x") + '\t' + aComponent->GetName() + string("_y") + '\t');
+        fLabel += (aComponent->GetName() + string("_x") + '\t' + aComponent->GetName() + string("_y") + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "KTwoVector", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "KTwoVector", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
     auto* tThreeVector = aComponent->As<KThreeVector>();
     if (tThreeVector != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a three_vector" << eom);
-        string str = (aComponent->GetName() + string("_x") + '\t' + aComponent->GetName() + string("_y") + '\t' +
-                      aComponent->GetName() + string("_z") + '\t');
+        fLabel += (aComponent->GetName() + string("_x") + '\t' + aComponent->GetName() + string("_y") + '\t' +
+                   aComponent->GetName() + string("_z") + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "KThreeVector", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "KThreeVector", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tTwoMatrix = aComponent->As<KTwoMatrix>();
     if (tTwoMatrix != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a two_matrix" << eom);
-        string str = (aComponent->GetName() + string("_xx") + '\t' + aComponent->GetName() + string("_xy") +
-                      aComponent->GetName() + string("_yx") + '\t' + aComponent->GetName() + string("_yy"));
+        fLabel += (aComponent->GetName() + string("_xx") + '\t' + aComponent->GetName() + string("_xy") +
+                   aComponent->GetName() + string("_yx") + '\t' + aComponent->GetName() + string("_yy"));
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "KTwoMatrix", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "KTwoMatrix", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
+    
     auto* tThreeMatrix = aComponent->As<KThreeMatrix>();
     if (tThreeMatrix != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a three_matrix" << eom);
-        string str = (aComponent->GetName() + string("_xx") + '\t' + aComponent->GetName() + string("_xy") + '\t' + aComponent->GetName() + string("_xz") + '\t' +
-                      aComponent->GetName() + string("_yx") + '\t' + aComponent->GetName() + string("_yy") + '\t' + aComponent->GetName() + string("_yz") + '\t' +
-                      aComponent->GetName() + string("_zx") + '\t' + aComponent->GetName() + string("_zy") + '\t' + aComponent->GetName() + string("_zz") + '\t');
+        fLabel += (aComponent->GetName() + string("_xx") + '\t' + aComponent->GetName() + string("_xy") + '\t' + aComponent->GetName() + string("_xz") + '\t' +
+                   aComponent->GetName() + string("_yx") + '\t' + aComponent->GetName() + string("_yy") + '\t' + aComponent->GetName() + string("_yz") + '\t' +
+                   aComponent->GetName() + string("_zx") + '\t' + aComponent->GetName() + string("_zy") + '\t' + aComponent->GetName() + string("_zz") + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "KThreeMatrix", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "KThreeMatrix", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tBool = aComponent->As<bool>();
     if (tBool != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a bool" << eom);
-       string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "bool", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "bool", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tUChar = aComponent->As<unsigned char>();
     if (tUChar != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is an unsigned_char" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "unsigned char", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "unsigned char", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tChar = aComponent->As<char>();
     if (tChar != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a char" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "char", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "char", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tUShort = aComponent->As<unsigned short>();
     if (tUShort != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is an unsigned_short" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "unsigned short", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "unsigned short", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tShort = aComponent->As<short>();
     if (tShort != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a short" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "short", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "short", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tUInt = aComponent->As<unsigned int>();
     if (tUInt != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a unsigned_int" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "unsigned int", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "unsigned int", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tInt = aComponent->As<int>();
     if (tInt != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is an int" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "int", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "int", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tULong = aComponent->As<unsigned long>();
     if (tULong != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is an unsigned_long" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "unsigned long", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "unsigned long", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tLong = aComponent->As<long>();
     if (tLong != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a long" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "long", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "long", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tLongLong = aComponent->As<long long>();
     if (tLongLong != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a long_long" << eom);
-        string str = (aComponent->GetName() + '\t');
+        fLabel += (aComponent->GetName() + '\t');
 
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "long_long", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        auto* obj = new OutputObjectASCII(aComponent, "long_long", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tFloat = aComponent->As<float>();
     if (tFloat != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a float" << eom);
-        string str = (aComponent->GetName() + '\t');
-
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "float", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        fLabel += (aComponent->GetName() + '\t');
+        
+        auto* obj = new OutputObjectASCII(aComponent, "float", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     auto* tDouble = aComponent->As<double>();
     if (tDouble != nullptr) {
         wtrmsg_debug("  object <" << aComponent->GetName() << "> is a double" << eom);
-        string str = (aComponent->GetName() + '\t');
-
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
-
-        if (aTrack == 0) {
-            auto* obj = new OutputObjectASCII(aComponent, "double", fWriter->Precision());
-            fOutputObjectASCIIs.push_back(obj);
-            fComponents.push_back(aComponent);
-        }
+        fLabel += (aComponent->GetName() + '\t');
+        
+        auto* obj = new OutputObjectASCII(aComponent, "double", aPrecision);
+        fOutputObjectASCIIs.push_back(obj);
+        fComponents.push_back(aComponent);
+        
         return;
     }
 
     wtrmsg(eError) << "ASCII writer cannot add object <" << aComponent->GetName() << ">" << eom;
 
+    fLabel += "error";
     return;
 }
 
@@ -514,8 +446,10 @@ void KSWriteASCII::ExecuteRun()
     if (fStepIndex != 0)
         fRunLastStepIndex = fStepIndex - 1;
 
+    Write("run\t");
     for (auto& activeRunComponent : fActiveRunComponents)
         Write(activeRunComponent.second->ValuesAsString());
+    Write("\n");
 
     fRunIndex++;
     fRunFirstEventIndex = fEventIndex;
@@ -535,8 +469,10 @@ void KSWriteASCII::ExecuteEvent()
     if (fStepIndex != 0)
         fEventLastStepIndex = fStepIndex - 1;
 
+    Write("event\t");
     for (auto& activeEventComponent : fActiveEventComponents)
         Write(activeEventComponent.second->ValuesAsString());
+    Write("\n");
 
     fEventIndex++;
     fEventFirstTrackIndex = fTrackIndex;
@@ -551,33 +487,16 @@ void KSWriteASCII::ExecuteTrack()
     if (fStepIndex != 0)
         fTrackLastStepIndex = fStepIndex - 1;
 
-    fTextFile->File()->put('\n');
+    Write("track\t");
     for (auto& activeTrackComponent : fActiveTrackComponents)
         Write(activeTrackComponent.second->ValuesAsString());
+    Write("\n");
 
     wtrmsg(eNormal) << "ASCII output was written to file <" << fTextFile->GetName() << ">" << eom;
     fTextFile->Close();
 
     delete fTextFile;
-
-    // new output file
-
-    fTextFile = MakeOutputFile(fTrackIndex + 1);
-    if (fTextFile->Open(KFile::eWrite) == true) {
-        // do nothing here
-    }
-    else {
-        wtrmsg(eError) << "could not open ASCII output file" << eom;
-    }
-
-    ComponentIt tIt;
-
-    for (tIt = fTrackComponents.begin(); tIt != fTrackComponents.end(); tIt++)
-        tIt->second->MakeTitle(tIt->first, 0);
-
-    fTextFile->File()->put('\n');
-    for (tIt = fStepComponents.begin(); tIt != fStepComponents.end(); tIt++)
-        tIt->second->MakeTitle(tIt->first, 1);
+    fTextFile = nullptr;
 
     fTrackIndex++;
     fTrackFirstStepIndex = fStepIndex;
@@ -593,13 +512,14 @@ void KSWriteASCII::ExecuteStep()
         return;
     }
 
-    fTextFile->File()->put('\n');
+    Write("step\t");
     if (fStepComponent == true) {
         wtrmsg_debug("ASCII writer <" << GetName() << "> is filling a step" << eom);
 
         for (auto& activeStepComponent : fActiveStepComponents)
             Write(activeStepComponent.second->ValuesAsString());
     }
+    Write("\n");
 
     fStepIndex++;
     fStepIterationIndex++;
@@ -617,7 +537,7 @@ void KSWriteASCII::AddRunComponent(KSComponent* aComponent)
         fKey = aComponent->GetName();
 
 
-        auto* tRunData = new Data(aComponent, this);
+        auto* tRunData = new Data(aComponent, Precision());
         tIt = fRunComponents.insert(ComponentEntry(aComponent, tRunData)).first;
     }
 
@@ -649,7 +569,7 @@ void KSWriteASCII::AddEventComponent(KSComponent* aComponent)
 
         fKey = aComponent->GetName();
 
-        auto* tEventData = new Data(aComponent, this);
+        auto* tEventData = new Data(aComponent, Precision());
         tIt = fEventComponents.insert(ComponentEntry(aComponent, tEventData)).first;
     }
 
@@ -682,7 +602,7 @@ void KSWriteASCII::AddTrackComponent(KSComponent* aComponent)
 
         fKey = aComponent->GetName();
 
-        auto* tTrackData = new Data(aComponent, this);
+        auto* tTrackData = new Data(aComponent, Precision());
         tIt = fTrackComponents.insert(ComponentEntry(aComponent, tTrackData)).first;
     }
 
@@ -717,7 +637,7 @@ void KSWriteASCII::AddStepComponent(KSComponent* aComponent)
 
         fKey = aComponent->GetName();
 
-        auto* tStepData = new Data(aComponent, this);
+        auto* tStepData = new Data(aComponent, Precision());
 
         tIt = fStepComponents.insert(ComponentEntry(aComponent, tStepData)).first;
     }
@@ -747,15 +667,6 @@ void KSWriteASCII::InitializeComponent()
 {
     wtrmsg_debug("starting ASCII writer" << eom);
 
-    fTextFile = MakeOutputFile(fTrackIndex);
-
-    if (fTextFile->Open(KFile::eWrite) == true) {
-        // do nothing here
-    }
-    else {
-        wtrmsg(eError) << "could not open ASCII output file" << eom;
-    }
-
     return;
 }
 
@@ -770,14 +681,17 @@ void KSWriteASCII::DeinitializeComponent()
     for (tIt = fStepComponents.begin(); tIt != fStepComponents.end(); tIt++)
         delete tIt->second;
 
-    fTextFile->Close();
+    if (fTextFile) {
+        fTextFile->Close();
 
-    delete fTextFile;
+        delete fTextFile;
+        fTextFile = nullptr;
+    }
 
     return;
 }
 
-KTextFile* KSWriteASCII::MakeOutputFile(int anIndex) const
+void KSWriteASCII::MakeOutputFile(int anIndex)
 {
     stringstream s;
     s << fBase << "_Track" << anIndex << +".txt";
@@ -787,7 +701,39 @@ KTextFile* KSWriteASCII::MakeOutputFile(int anIndex) const
 #ifdef Kassiopeia_USE_BOOST
     KPathUtils::MakeDirectory(tPath);
 #endif
-    return KTextFile::CreateOutputTextFile(tPath, tBase);
+    
+    fTextFile = KTextFile::CreateOutputTextFile(tPath, tBase);
+    
+    // Test file
+    if (fTextFile->Open(KFile::eWrite) == true) {
+        // do nothing here
+    }
+    else {
+        wtrmsg(eError) << "could not open ASCII output file" << eom;
+    }
+
+    //Write header
+    ComponentIt tIt;
+    
+    Write("# Run: ");
+    for (tIt = fActiveRunComponents.begin(); tIt != fActiveRunComponents.end(); tIt++)
+        Write(tIt->second->Label());
+    Write('\n');
+    
+    Write("# Event: ");
+    for (tIt = fActiveEventComponents.begin(); tIt != fActiveEventComponents.end(); tIt++)
+        Write(tIt->second->Label());
+    Write('\n');
+    
+    Write("# Track: ");
+    for (tIt = fActiveTrackComponents.begin(); tIt != fActiveTrackComponents.end(); tIt++)
+        Write(tIt->second->Label());
+    Write('\n');
+    
+    Write("# Step: ");
+    for (tIt = fActiveStepComponents.begin(); tIt != fActiveStepComponents.end(); tIt++)
+        Write(tIt->second->Label());
+    Write('\n');
 }
 
 STATICINT sKSWriteASCIIDict =

--- a/Kassiopeia/Writers/Source/KSWriteASCII.cxx
+++ b/Kassiopeia/Writers/Source/KSWriteASCII.cxx
@@ -29,14 +29,14 @@ const int KSWriteASCII::fBufferSize = 64000;
 const int KSWriteASCII::fSplitLevel = 99;
 const string KSWriteASCII::fLabel = string("KASSIOPEIA_TREE_DATA");
 
-KSWriteASCII::Data::Objekt::Objekt(KSComponent* aComponent, string aType, int aPrecision)
+KSWriteASCII::Data::OutputObjectASCII::OutputObjectASCII(KSComponent* aComponent, string aType, int aPrecision)
 {
     fComponent = aComponent;
     fType = aType;
     fPrecision = aPrecision;
 }
 
-string KSWriteASCII::Data::Objekt::getValue()
+string KSWriteASCII::Data::OutputObjectASCII::getValue()
 {
     stringstream s;
     s << std::setprecision(fPrecision);
@@ -120,7 +120,7 @@ void KSWriteASCII::Data::Start(const unsigned int& anIndex)
 void KSWriteASCII::Data::Fill()
 {
     KSComponent* tComponent;
-    Objekt* tObjekt;
+    OutputObjectASCII* tOutputObjectASCII;
     vector<KSComponent*>::iterator tIt;
 
     for (tIt = fComponents.begin(); tIt != fComponents.end(); ++tIt) {
@@ -129,9 +129,9 @@ void KSWriteASCII::Data::Fill()
     }
 
     string str;
-    for (auto& objekt : fObjekts) {
-        tObjekt = objekt;
-        str = tObjekt->getValue();
+    for (auto& outputObjectASCII : fOutputObjectASCIIs) {
+        tOutputObjectASCII = outputObjectASCII;
+        str = tOutputObjectASCII->getValue();
 
         for (char& it : str)
             fWriter->TextFile()->File()->put(it);
@@ -168,8 +168,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "string", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "string", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
 
@@ -185,8 +185,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "KTwoVector", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "KTwoVector", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -201,8 +201,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "KThreeVector", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "KThreeVector", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -218,8 +218,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "KTwoMatrix", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "KTwoMatrix", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -235,8 +235,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "KThreeMatrix", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "KThreeMatrix", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -251,8 +251,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "bool", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "bool", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -267,8 +267,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "unsigned char", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "unsigned char", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -283,8 +283,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "char", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "char", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -299,8 +299,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "unsigned short", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "unsigned short", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -315,8 +315,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "short", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "short", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -331,8 +331,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "unsigned int", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "unsigned int", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -347,8 +347,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "int", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "int", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -363,8 +363,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "unsigned long", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "unsigned long", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -379,8 +379,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "long", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "long", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -395,8 +395,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "long_long", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "long_long", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -411,8 +411,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "float", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "float", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;
@@ -427,8 +427,8 @@ void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
             fWriter->TextFile()->File()->put(it);
 
         if (aTrack == 0) {
-            auto* obj = new Objekt(aComponent, "double", fWriter->Precision());
-            fObjekts.push_back(obj);
+            auto* obj = new OutputObjectASCII(aComponent, "double", fWriter->Precision());
+            fOutputObjectASCIIs.push_back(obj);
             fComponents.push_back(aComponent);
         }
         return;

--- a/Kassiopeia/Writers/Source/KSWriteASCII.cxx
+++ b/Kassiopeia/Writers/Source/KSWriteASCII.cxx
@@ -86,17 +86,6 @@ string KSWriteASCII::Data::OutputObjectASCII::getValue()
     return s.str();
 }
 
-KSWriteASCII::Data::Data(KSComponent* aComponent) :
-    fLabel(""),
-    fType(""),
-    fWriter(),
-    fIndex(0),
-    fLength(0),
-    fComponents()
-{
-    MakeTitle(aComponent, 0);
-}
-
 KSWriteASCII::Data::Data(KSComponent* aComponent, KSWriteASCII* aWriter) :
     fLabel(""),
     fType(""),

--- a/Kassiopeia/Writers/Source/KSWriteASCII.cxx
+++ b/Kassiopeia/Writers/Source/KSWriteASCII.cxx
@@ -106,24 +106,19 @@ void KSWriteASCII::Data::Start(const unsigned int& anIndex)
     return;
 }
 
-void KSWriteASCII::Data::Fill()
+std::string KSWriteASCII::Data::ValuesAsString()
 {
     KSComponent* tComponent;
-    OutputObjectASCII* tOutputObjectASCII;
     vector<KSComponent*>::iterator tIt;
+    string result;
 
     for (tIt = fComponents.begin(); tIt != fComponents.end(); ++tIt) {
         tComponent = (*tIt);
         tComponent->PullUpdate();
     }
 
-    string str;
-    for (auto& outputObjectASCII : fOutputObjectASCIIs) {
-        tOutputObjectASCII = outputObjectASCII;
-        str = tOutputObjectASCII->getValue();
-
-        for (char& it : str)
-            fWriter->TextFile()->File()->put(it);
+    for (OutputObjectASCII*& outputObjectASCII : fOutputObjectASCIIs) {
+        result += outputObjectASCII->getValue();
     }
 
     for (tIt = fComponents.begin(); tIt != fComponents.end(); ++tIt) {
@@ -132,7 +127,7 @@ void KSWriteASCII::Data::Fill()
     }
 
     fLength++;
-    return;
+    return result;
 }
 
 void KSWriteASCII::Data::MakeTitle(KSComponent* aComponent, int aTrack)
@@ -520,7 +515,7 @@ void KSWriteASCII::ExecuteRun()
         fRunLastStepIndex = fStepIndex - 1;
 
     for (auto& activeRunComponent : fActiveRunComponents)
-        activeRunComponent.second->Fill();
+        Write(activeRunComponent.second->ValuesAsString());
 
     fRunIndex++;
     fRunFirstEventIndex = fEventIndex;
@@ -541,7 +536,7 @@ void KSWriteASCII::ExecuteEvent()
         fEventLastStepIndex = fStepIndex - 1;
 
     for (auto& activeEventComponent : fActiveEventComponents)
-        activeEventComponent.second->Fill();
+        Write(activeEventComponent.second->ValuesAsString());
 
     fEventIndex++;
     fEventFirstTrackIndex = fTrackIndex;
@@ -558,7 +553,7 @@ void KSWriteASCII::ExecuteTrack()
 
     fTextFile->File()->put('\n');
     for (auto& activeTrackComponent : fActiveTrackComponents)
-        activeTrackComponent.second->Fill();
+        Write(activeTrackComponent.second->ValuesAsString());
 
     wtrmsg(eNormal) << "ASCII output was written to file <" << fTextFile->GetName() << ">" << eom;
     fTextFile->Close();
@@ -603,7 +598,7 @@ void KSWriteASCII::ExecuteStep()
         wtrmsg_debug("ASCII writer <" << GetName() << "> is filling a step" << eom);
 
         for (auto& activeStepComponent : fActiveStepComponents)
-            activeStepComponent.second->Fill();
+            Write(activeStepComponent.second->ValuesAsString());
     }
 
     fStepIndex++;


### PR DESCRIPTION
Previously, there were multiple issues with KSWriteASCII:
 * Headers could be in a different order than actual values (especially problematic since the order of the actual values seems to be somewhat random as found by executing the same simulation multiple times - this should be understood and fixed ideally, I couldn't understand it yet)
 * The header contained a mix of output for step and track
 * Likely run and event output was not correctly written to new lines

This is fixed by this commit:

Previous output:
```
gc_velocity_x	gc_velocity_y	gc_velocity_z	longitudinal_force	transverse_force	track_id	creator_name	terminator_name	total_steps	total_length	cont_energy_loss	disc_energy_loss	pixel_number	initial_time	initial_position_x	initial_position_y	initial_position_z	initial_radius	initial_magnetic_field_x	initial_magnetic_field_y	initial_magnetic_field_z	initial_electric_potential	initial_azimuthal_angle_to_x	initial_polar_angle_to_b	initial_kinetic_energy	final_time	final_position_x	final_position_y	final_position_z	final_magnetic_field_x	final_magnetic_field_y	final_magnetic_field_z	final_electric_potential	final_azimuthal_angle_to_x	final_polar_angle_to_b	final_kinetic_energy	maximal_magnetic_field_x	maximal_magnetic_field_y	maximal_magnetic_field_z	minimal_magnetic_field_x	minimal_magnetic_field_y	minimal_magnetic_field_z	maximal_electric_potential	minimal_electric_potential	step_id	step_length	cont_energy_loss	disc_energy_loss	time	position_x	position_y	position_z	momentum_x	momentum_y	momentum_z	magnetic_field_x	magnetic_field_y	magnetic_field_z	electric_field_x	electric_field_y	electric_field_z	electric_potential	polar_angle_to_b	kinetic_energy	longitudinal_kinetic_energy	
0	0.0118415	2.18279e-11	0	0	0.000925499	-0.000192499	-46.8343	-6.30205e-28	1.13437e-27	7.43511e-23	-4.60365e-05	-0.00148249	-0.492487	0	0	0	0	179.828	18600	18599.8	-192.971	-1430.19	4.46408	6.8586e-33	2.16194e-30	
1	0.0112013	0	0	1.50361e-10	0.000924978	-0.000155751	-46.8224	-1.91241e-26	-2.11848e-27	7.43511e-23	8.46511e-05	-0.00163606	-0.520617	0	0	0	0	179.818	18600	18599.8	-60.4305	-1229.88	3.86783	6.02887e-33	1.84457e-30	
2	0.0105529	3.63798e-12	0	2.92593e-10	0.000921915	-0.000120606	-46.8112	-3.53132e-26	-7.71004e-27	7.43511e-23	0.000208816	-0.00174806	-0.552605	0	0	0	0	179.813	18600	18599.8	56.0839	-1035.56	3.30716	5.20784e-33	1.54459e-30	
3	0.00991652	0	0	4.26591e-10	0.000916941	-8.73561e-05	-46.8007	-4.91636e-26	-1.53396e-26	7.43511e-23	0.0003301	-0.00186058	-0.588065	0	0	0	0	179.807	18600	18599.8	155.302	-855.047	2.80018	4.43308e-33	1.27373e-30	
4	0.00930669	-3.63798e-12	0	5.52509e-10	0.000910613	-5.61704e-05	-46.7907	-6.078e-26	-2.46789e-26	7.43511e-23	0.000447667	-0.00197187	-0.626599	0	0	0	0	179.801	18600	18599.8	237.579	-692.564	2.35473	3.7263e-33	1.0371e-30	
5	0.00873253	3.63798e-12	0	6.70683e-10	0.00090339	-2.71099e-05	-46.7814	-7.03446e-26	-3.54029e-26	7.43511e-23	0.00056076	-0.00208036	-0.667797	0	0	0	0	179.794	18600	18599.8	304.238	-549.652	1.97141	3.09703e-33	8.35214e-31	
6	0.00819895	-3.63798e-12	0	7.81567e-10	0.000895637	-1.56032e-07	-46.7727	-7.80778e-26	-4.7209e-26	7.43511e-23	0.000668712	-0.00218462	-0.711257	0	0	0	0	179.788	18600	18599.7	357.071	-426.068	1.64641	2.54648e-33	6.65851e-31	
7	0.00770771	3.63798e-12	0	8.85676e-10	0.000887629	2.4765e-05	-46.7645	-8.42105e-26	-5.9828e-26	7.43511e-23	0.000770963	-0.00228342	-0.756588	0	0	0	0	179.781	18600	18599.7	397.988	-320.53	1.37367	2.07082e-33	5.25455e-31	
8	0.0072584	0	0	9.83547e-10	0.000879572	4.77621e-05	-46.7568	-8.89656e-26	-7.30272e-26	7.43511e-23	0.000867063	-0.00237577	-0.803423	0	0	0	0	179.774	18600	18599.7	428.822	-231.251	1.14633	1.66352e-33	4.10037e-31	
9	0.00684924	0	0	1.07571e-09	0.000871608	6.89632e-05	-46.7495	-9.25486e-26	-8.66099e-26	7.4351e-23	0.000956669	-0.00246087	-0.851417	0	0	0	0	179.768	18600	18599.7	451.231	-156.277	0.957622	1.31701e-33	3.15697e-31	
```

New output:
```
# Run: 
# Event: 
# Track: track_id	creator_name	terminator_name	total_steps	total_length	cont_energy_loss	disc_energy_loss	pixel_number	initial_time	initial_position_x	initial_position_y	initial_position_z	initial_radius	initial_magnetic_field_x	initial_magnetic_field_y	initial_magnetic_field_z	initial_electric_potential	initial_azimuthal_angle_to_x	initial_polar_angle_to_b	initial_kinetic_energy	final_time	final_position_x	final_position_y	final_position_z	final_magnetic_field_x	final_magnetic_field_y	final_magnetic_field_z	final_electric_potential	final_azimuthal_angle_to_x	final_polar_angle_to_b	final_kinetic_energy	maximal_magnetic_field_x	maximal_magnetic_field_y	maximal_magnetic_field_z	minimal_magnetic_field_x	minimal_magnetic_field_y	minimal_magnetic_field_z	maximal_electric_potential	minimal_electric_potential	
# Step: step_id	step_length	cont_energy_loss	disc_energy_loss	time	position_x	position_y	position_z	momentum_x	momentum_y	momentum_z	magnetic_field_x	magnetic_field_y	magnetic_field_z	electric_field_x	electric_field_y	electric_field_z	electric_potential	polar_angle_to_b	kinetic_energy	longitudinal_kinetic_energy	gc_velocity_x	gc_velocity_y	gc_velocity_z	longitudinal_force	transverse_force	
step	0	0.0118415	2.18279e-11	0	0	0.000925499	-0.000192499	-46.8343	-6.30205e-28	1.13437e-27	7.43511e-23	-4.60365e-05	-0.00148249	-0.492487	0	0	0	0	179.828	18600	18599.8	-192.971	-1430.19	4.46408	6.8586e-33	2.16194e-30	
step	1	0.0112013	0	0	1.50361e-10	0.000924978	-0.000155751	-46.8224	-1.91241e-26	-2.11848e-27	7.43511e-23	8.46511e-05	-0.00163606	-0.520617	0	0	0	0	179.818	18600	18599.8	-60.4305	-1229.88	3.86783	6.02887e-33	1.84457e-30	
step	2	0.0105529	3.63798e-12	0	2.92593e-10	0.000921915	-0.000120606	-46.8112	-3.53132e-26	-7.71004e-27	7.43511e-23	0.000208816	-0.00174806	-0.552605	0	0	0	0	179.813	18600	18599.8	56.0839	-1035.56	3.30716	5.20784e-33	1.54459e-30	
step	3	0.00991652	0	0	4.26591e-10	0.000916941	-8.73561e-05	-46.8007	-4.91636e-26	-1.53396e-26	7.43511e-23	0.0003301	-0.00186058	-0.588065	0	0	0	0	179.807	18600	18599.8	155.302	-855.047	2.80018	4.43308e-33	1.27373e-30	
step	4	0.00930669	-3.63798e-12	0	5.52509e-10	0.000910613	-5.61704e-05	-46.7907	-6.078e-26	-2.46789e-26	7.43511e-23	0.000447667	-0.00197187	-0.626599	0	0	0	0	179.801	18600	18599.8	237.579	-692.564	2.35473	3.7263e-33	1.0371e-30	
step	5	0.00873253	3.63798e-12	0	6.70683e-10	0.00090339	-2.71099e-05	-46.7814	-7.03446e-26	-3.54029e-26	7.43511e-23	0.00056076	-0.00208036	-0.667797	0	0	0	0	179.794	18600	18599.8	304.238	-549.652	1.97141	3.09703e-33	8.35214e-31	
step	6	0.00819895	-3.63798e-12	0	7.81567e-10	0.000895637	-1.56032e-07	-46.7727	-7.80778e-26	-4.7209e-26	7.43511e-23	0.000668712	-0.00218462	-0.711257	0	0	0	0	179.788	18600	18599.7	357.071	-426.068	1.64641	2.54648e-33	6.65851e-31	
step	7	0.00770771	3.63798e-12	0	8.85676e-10	0.000887629	2.4765e-05	-46.7645	-8.42105e-26	-5.9828e-26	7.43511e-23	0.000770963	-0.00228342	-0.756588	0	0	0	0	179.781	18600	18599.7	397.988	-320.53	1.37367	2.07082e-33	5.25455e-31	
step	8	0.0072584	0	0	9.83547e-10	0.000879572	4.77621e-05	-46.7568	-8.89656e-26	-7.30272e-26	7.43511e-23	0.000867063	-0.00237577	-0.803423	0	0	0	0	179.774	18600	18599.7	428.822	-231.251	1.14633	1.66352e-33	4.10037e-31	
step	9	0.00684924	0	0	1.07571e-09	0.000871608	6.89632e-05	-46.7495	-9.25486e-26	-8.66099e-26	7.4351e-23	0.000956669	-0.00246087	-0.851417	0	0	0	0	179.768	18600	18599.7	451.231	-156.277	0.957622	1.31701e-33	3.15697e-31	
```

It has to be noted that I have absolutely no idea why the old `MakeTitle` function that I converted to a partially recursive `Initialize` function was called multiple times before (it was called again each time a new file was created for a new track) and that seemingly didn't cause issues.