### PR TITLE
Fix cosine angle generator constructor 

### DIFF
--- a/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
@@ -22,8 +22,13 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
         const std::string& tok = aContainer->AsReference<std::string>();
         if (KStringUtils::IContains(tok, "mol"))
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::MolecularFlow);
-        else
+        else if (KStringUtils::IContains(tok, "clas"))
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::Classic);
+        else {
+            objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">" << eom;
+            objctmsg(eError) << "ksgen_value_angle_cosine: valid modes are <molecular_flow> or <classic>" << eom;
+            return false;
+        }
         return true;
     }
     if (aContainer->GetName() == "angle_min") {
@@ -35,7 +40,16 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
         return true;
     }
     if (aContainer->GetName() == "direction") {
-        aContainer->CopyTo(fObject, &KSGenValueAngleCosine::SetDirection);
+        const std::string& tok = aContainer->AsReference<std::string>();
+        if (KStringUtils::IContains(tok, "for"))
+            fObject->SetDirection(KSGenValueAngleCosine::EDirection::Forward);
+        else if (KStringUtils::IContains(tok, "back"))
+            fObject->SetDirection(KSGenValueAngleCosine::EDirection::Backward);
+        else {
+            objctmsg(eError) << "ksgen_value_angle_cosine: invalid direction <" << tok << ">" << eom;
+            objctmsg(eError) << "ksgen_value_angle_cosine: valid directions are <forward> or <backward>" << eom;
+            return false;
+        }
         return true;
     }
     return false;

--- a/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
@@ -34,6 +34,10 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
         aContainer->CopyTo(fObject, &KSGenValueAngleCosine::SetAngleMax);
         return true;
     }
+    if (aContainer->GetName() == "direction") {
+        aContainer->CopyTo(fObject, &KSGenValueAngleCosine::SetDirection);
+        return true;
+    }
     return false;
 }
 

--- a/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
@@ -26,7 +26,8 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::Classic);
         else {
             objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">" << "\n"
-                             << "ksgen_value_angle_cosine: Valid modes are <molecular_flow> or <classic>" << eom;
+                             << "ksgen_value_angle_cosine: Valid modes are <molecular_flow> or <classic> \n"
+                             << "This error message was added 04/2025. Before, the default classic was used" << eom;
             return false;
         }
         return true;

--- a/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
@@ -27,7 +27,7 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
         else {
             objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">" << "\n"
                              << "ksgen_value_angle_cosine: Valid modes are <molecular_flow> or <classic> \n"
-                             << "This error message was added 04/2025. Before, the default classic was used" << eom;
+                             << "This error message was added 04/2025. Before, this configuration corresponded to <classic>." << eom;
             return false;
         }
         return true;

--- a/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
@@ -20,13 +20,13 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
     }
     if (aContainer->GetName() == "mode") {
         const std::string& tok = aContainer->AsReference<std::string>();
-        if (KBaseStringUtils::IEquals(tok, "molecular"))
+        if (KStringUtils::IContains(tok, "mol"))
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::MolecularFlow);
-        else if (KBaseStringUtils::IEquals(tok, "classic"))
+        else if (KStringUtils::IContains(tok, "clas"))
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::Classic);
         else {
             objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">" << "\n"
-                             << "ksgen_value_angle_cosine: Valid modes are <molecular> or <classic>" << eom;
+                             << "ksgen_value_angle_cosine: Valid modes are <molecular_flow> or <classic>" << eom;
             return false;
         }
         return true;
@@ -41,9 +41,9 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
     }
     if (aContainer->GetName() == "direction") {
         const std::string& tok = aContainer->AsReference<std::string>();
-        if (KBaseStringUtils::IEquals(tok, "forward"))
+        if (KStringUtils::IContains(tok, "for"))
             fObject->SetDirection(KSGenValueAngleCosine::EDirection::Forward);
-        else if (KBaseStringUtils::IEquals(tok, "backward"))
+        else if (KStringUtils::IContains(tok, "back"))
             fObject->SetDirection(KSGenValueAngleCosine::EDirection::Backward);
         else {
             objctmsg(eError) << "ksgen_value_angle_cosine: invalid direction <" << tok << ">" << "\n"

--- a/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
@@ -25,8 +25,8 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
         else if (KStringUtils::IContains(tok, "clas"))
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::Classic);
         else {
-            objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">"
-                             << "ksgen_value_angle_cosine: valid modes are <molecular_flow> or <classic>" << eom;
+            objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">" << "\n"
+                             << "ksgen_value_angle_cosine: Valid modes are <molecular_flow> or <classic>" << eom;
             return false;
         }
         return true;
@@ -46,7 +46,7 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
         else if (KStringUtils::IContains(tok, "back"))
             fObject->SetDirection(KSGenValueAngleCosine::EDirection::Backward);
         else {
-            objctmsg(eError) << "ksgen_value_angle_cosine: invalid direction <" << tok << ">"
+            objctmsg(eError) << "ksgen_value_angle_cosine: invalid direction <" << tok << ">" << "\n"
                              << "ksgen_value_angle_cosine: valid directions are <forward> or <backward>" << eom;
             return false;
         }

--- a/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
@@ -25,8 +25,8 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
         else if (KStringUtils::IContains(tok, "clas"))
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::Classic);
         else {
-            objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">" << eom;
-            objctmsg(eError) << "ksgen_value_angle_cosine: valid modes are <molecular_flow> or <classic>" << eom;
+            objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">"
+                             << "ksgen_value_angle_cosine: valid modes are <molecular_flow> or <classic>" << eom;
             return false;
         }
         return true;
@@ -46,8 +46,8 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
         else if (KStringUtils::IContains(tok, "back"))
             fObject->SetDirection(KSGenValueAngleCosine::EDirection::Backward);
         else {
-            objctmsg(eError) << "ksgen_value_angle_cosine: invalid direction <" << tok << ">" << eom;
-            objctmsg(eError) << "ksgen_value_angle_cosine: valid directions are <forward> or <backward>" << eom;
+            objctmsg(eError) << "ksgen_value_angle_cosine: invalid direction <" << tok << ">"
+                             << "ksgen_value_angle_cosine: valid directions are <forward> or <backward>" << eom;
             return false;
         }
         return true;

--- a/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
+++ b/Kassiopeia/Bindings/Generators/Include/KSGenValueAngleCosineBuilder.h
@@ -20,13 +20,13 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
     }
     if (aContainer->GetName() == "mode") {
         const std::string& tok = aContainer->AsReference<std::string>();
-        if (KStringUtils::IContains(tok, "mol"))
+        if (KBaseStringUtils::IEquals(tok, "molecular"))
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::MolecularFlow);
-        else if (KStringUtils::IContains(tok, "clas"))
+        else if (KBaseStringUtils::IEquals(tok, "classic"))
             fObject->SetMode(KSGenValueAngleCosine::EDistributionMode::Classic);
         else {
             objctmsg(eError) << "ksgen_value_angle_cosine: invalid mode <" << tok << ">" << "\n"
-                             << "ksgen_value_angle_cosine: Valid modes are <molecular_flow> or <classic>" << eom;
+                             << "ksgen_value_angle_cosine: Valid modes are <molecular> or <classic>" << eom;
             return false;
         }
         return true;
@@ -41,9 +41,9 @@ template<> inline bool KSGenValueAngleCosineBuilder::AddAttribute(KContainer* aC
     }
     if (aContainer->GetName() == "direction") {
         const std::string& tok = aContainer->AsReference<std::string>();
-        if (KStringUtils::IContains(tok, "for"))
+        if (KBaseStringUtils::IEquals(tok, "forward"))
             fObject->SetDirection(KSGenValueAngleCosine::EDirection::Forward);
-        else if (KStringUtils::IContains(tok, "back"))
+        else if (KBaseStringUtils::IEquals(tok, "backward"))
             fObject->SetDirection(KSGenValueAngleCosine::EDirection::Backward);
         else {
             objctmsg(eError) << "ksgen_value_angle_cosine: invalid direction <" << tok << ">" << "\n"

--- a/Kassiopeia/Bindings/Generators/Source/KSGenValueAngleCosineBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenValueAngleCosineBuilder.cxx
@@ -13,7 +13,8 @@ template<> KSGenValueAngleCosineBuilder::~KComplexElement() = default;
 STATICINT sKSGenValueAngleCosineStructure = KSGenValueAngleCosineBuilder::Attribute<std::string>("name") +
                                             KSGenValueAngleCosineBuilder::Attribute<std::string>("mode") +
                                             KSGenValueAngleCosineBuilder::Attribute<double>("angle_min") +
-                                            KSGenValueAngleCosineBuilder::Attribute<double>("angle_max");
+                                            KSGenValueAngleCosineBuilder::Attribute<double>("angle_max") +
+                                            KSGenValueAngleCosineBuilder::Attribute<double>("direction");
 
 STATICINT sToolboxKSGenValueAngleCosine =
     KSRootBuilder::ComplexElement<KSGenValueAngleCosine>("ksgen_value_angle_cosine");

--- a/Kassiopeia/Bindings/Generators/Source/KSGenValueAngleCosineBuilder.cxx
+++ b/Kassiopeia/Bindings/Generators/Source/KSGenValueAngleCosineBuilder.cxx
@@ -14,7 +14,7 @@ STATICINT sKSGenValueAngleCosineStructure = KSGenValueAngleCosineBuilder::Attrib
                                             KSGenValueAngleCosineBuilder::Attribute<std::string>("mode") +
                                             KSGenValueAngleCosineBuilder::Attribute<double>("angle_min") +
                                             KSGenValueAngleCosineBuilder::Attribute<double>("angle_max") +
-                                            KSGenValueAngleCosineBuilder::Attribute<double>("direction");
+                                            KSGenValueAngleCosineBuilder::Attribute<std::string>("direction");
 
 STATICINT sToolboxKSGenValueAngleCosine =
     KSRootBuilder::ComplexElement<KSGenValueAngleCosine>("ksgen_value_angle_cosine");

--- a/Kassiopeia/Generators/Include/KSGenValueAngleCosine.h
+++ b/Kassiopeia/Generators/Include/KSGenValueAngleCosine.h
@@ -22,10 +22,15 @@ class KSGenValueAngleCosine : public KSComponentTemplate<KSGenValueAngleCosine, 
         Classic,
         MolecularFlow
     };
+    enum EDirection {
+        Forward,
+        Backward
+    };
 
     K_SET_GET(double, AngleMin)
     K_SET_GET(double, AngleMax)
     K_SET_GET(EDistributionMode, Mode)
+    K_SET_GET(EDirection, Direction)
 };
 
 }  // namespace Kassiopeia

--- a/Kassiopeia/Generators/Source/KSGenValueAngleCosine.cxx
+++ b/Kassiopeia/Generators/Source/KSGenValueAngleCosine.cxx
@@ -9,7 +9,7 @@ using katrin::KRandom;
 namespace Kassiopeia
 {
 
-KSGenValueAngleCosine::KSGenValueAngleCosine() : fAngleMin(0.), fAngleMax(0.) {}
+KSGenValueAngleCosine::KSGenValueAngleCosine() : fAngleMin(0.), fAngleMax(0.), fMode(EDistributionMode::Classic), fDirection(EDirection::Forward) {}
 KSGenValueAngleCosine::KSGenValueAngleCosine(const KSGenValueAngleCosine& aCopy) :
     KSComponent(aCopy),
     fAngleMin(aCopy.fAngleMin),
@@ -44,6 +44,10 @@ void KSGenValueAngleCosine::DiceValue(std::vector<double>& aDicedValues)
 
         double tSinTheta = KRandom::GetInstance().Uniform( tSinThetaMin, tSinThetaMax );
         tAngle = acos( sqrt( 1. - tSinTheta*tSinTheta ) );
+    }
+    
+    if (fDirection == EDirection::Backward) {
+        tAngle = katrin::KConst::Pi() - tAngle;
     }
 
     aDicedValues.push_back((180.0 / katrin::KConst::Pi()) * tAngle);

--- a/Kassiopeia/Generators/Source/KSGenValueAngleCosine.cxx
+++ b/Kassiopeia/Generators/Source/KSGenValueAngleCosine.cxx
@@ -14,7 +14,8 @@ KSGenValueAngleCosine::KSGenValueAngleCosine(const KSGenValueAngleCosine& aCopy)
     KSComponent(aCopy),
     fAngleMin(aCopy.fAngleMin),
     fAngleMax(aCopy.fAngleMax),
-    fMode(EDistributionMode::Classic)
+    fMode(aCopy.fMode),
+    fDirection(aCopy.fDirection)
 {}
 KSGenValueAngleCosine* KSGenValueAngleCosine::Clone() const
 {
@@ -45,7 +46,7 @@ void KSGenValueAngleCosine::DiceValue(std::vector<double>& aDicedValues)
         double tSinTheta = KRandom::GetInstance().Uniform( tSinThetaMin, tSinThetaMax );
         tAngle = acos( sqrt( 1. - tSinTheta*tSinTheta ) );
     }
-    
+
     if (fDirection == EDirection::Backward) {
         tAngle = katrin::KConst::Pi() - tAngle;
     }


### PR DESCRIPTION
The default constructor did not include a default value for the distribution that should be used. This meant that users needed to enter a distribution or otherwise the generated angle would just be 0. Further, the copy constructor always used the classic distribution. Both things have been fixed with this commit.

This pull request also includes an option to change the direction. As the angle can only take values between 0° and 90°, generation could only take place in one direction. 
Therefore, the generator now includes a direction parameter which specifies whether the direction is in forward (0° <= angle <= 90°) or backward direction (180° >= angle >= 90°).