### PR TITLE
Docker image: Fedora 40 => Fedora 42

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,12 @@ jobs:
         source root/bin/thisroot.sh && source install/bin/kasperenv.sh && ASAN_OPTIONS=detect_leaks=0 UnitTestKasper
       shell: bash
 
-  fedora_40:
+  fedora_41:
     strategy:
       matrix:
         use_clang: [false] # FIXME add "true" after solving https://github.com/KATRIN-Experiment/Kassiopeia/issues/87 
     runs-on: ubuntu-latest
-    container: fedora:40
+    container: fedora:41
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,12 @@ jobs:
         source root/bin/thisroot.sh && source install/bin/kasperenv.sh && ASAN_OPTIONS=detect_leaks=0 UnitTestKasper
       shell: bash
 
-  fedora_41:
+  fedora_42:
     strategy:
       matrix:
         use_clang: [false] # FIXME add "true" after solving https://github.com/KATRIN-Experiment/Kassiopeia/issues/87 
     runs-on: ubuntu-latest
-    container: fedora:41
+    container: fedora:42
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG KASSIOPEIA_GIT_COMMIT=""
 ARG KASSIOPEIA_CPUS=""
 
 # --- runtime-base ---
-FROM fedora:40 as runtime-base
+FROM fedora:41 as runtime-base
 ARG KASSIOPEIA_UID
 ARG KASSIOPEIA_USER
 ARG KASSIOPEIA_GID

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG KASSIOPEIA_GIT_COMMIT=""
 ARG KASSIOPEIA_CPUS=""
 
 # --- runtime-base ---
-FROM fedora:41 as runtime-base
+FROM fedora:42 as runtime-base
 ARG KASSIOPEIA_UID
 ARG KASSIOPEIA_USER
 ARG KASSIOPEIA_GID

--- a/Documentation/gh-pages/source/setup_manual.rst
+++ b/Documentation/gh-pages/source/setup_manual.rst
@@ -100,7 +100,7 @@ On a RedHat/Fedora Linux system, the packages can be installed through the comma
         boost-devel fftw-devel gsl-devel hdf5-devel libomp-devel liburing-devel libxml2-devel log4cxx-devel \
         ocl-icd-devel openmpi-devel openssl-devel sqlite-devel vtk-devel zlib-devel
 
-Tested on Fedora Linux 40.
+Tested on Fedora Linux 41.
 
 Required dependencies
 ----------------------

--- a/Documentation/gh-pages/source/setup_manual.rst
+++ b/Documentation/gh-pages/source/setup_manual.rst
@@ -100,7 +100,7 @@ On a RedHat/Fedora Linux system, the packages can be installed through the comma
         boost-devel fftw-devel gsl-devel hdf5-devel libomp-devel liburing-devel libxml2-devel log4cxx-devel \
         ocl-icd-devel openmpi-devel openssl-devel sqlite-devel vtk-devel zlib-devel
 
-Tested on Fedora Linux 41.
+Tested on Fedora Linux 42.
 
 Required dependencies
 ----------------------

--- a/KEMField/Source/IO/StructuredASCII/include/KSAObjectInputNode.hh
+++ b/KEMField/Source/IO/StructuredASCII/include/KSAObjectInputNode.hh
@@ -110,8 +110,9 @@ template<typename T, unsigned int U = 0> class KSAObjectInputNode : public KSAIn
 //special case, T inherits from KSAFixedSizeInputOutputObject
 template<typename T> class KSAObjectInputNode<T, 1> : public KSAInputNode
 {
-
   public:
+    using KSAInputNode::AddChild;
+
     KSAObjectInputNode(const std::string& name) : KSAInputNode(name)
     {
         fIndex = 0;
@@ -335,8 +336,9 @@ template<typename T, unsigned int U = 0> class KSAExternalObjectInputNode : publ
 //special case, T inherits from KSAFixedSizeInputOutputObject
 template<typename T> class KSAExternalObjectInputNode<T, 1> : public KSAInputNode
 {
-
   public:
+    using KSAInputNode::AddChild;
+
     KSAExternalObjectInputNode(const std::string& name) : KSAInputNode(name)
     {
         fIndex = 0;
@@ -769,6 +771,8 @@ template<typename T> class KSAObjectInputNode<std::vector<T>> : public KSAInputN
 template<typename T> class KSAObjectInputNode<std::vector<T*>> : public KSAInputNode
 {
   public:
+    using KSAInputNode::AddChild;
+
     KSAObjectInputNode(const std::string& name) : KSAInputNode(name)
     {
         fObject = new std::vector<T*>();

--- a/KEMField/Source/IO/StructuredASCII/include/KSAObjectInputNode.hh
+++ b/KEMField/Source/IO/StructuredASCII/include/KSAObjectInputNode.hh
@@ -637,6 +637,8 @@ class KSAAssociatedAllocatedToVectorPointerExternalObjectInputNode :
 template<typename T> class KSAObjectInputNode<std::vector<T>> : public KSAInputNode
 {
   public:
+    using KSAInputNode::AddChild;
+    
     KSAObjectInputNode(const std::string& name) : KSAInputNode(name)
     {
         fObject = new std::vector<T>();

--- a/KGeoBag/Source/Shapes/External/Source/happly.h
+++ b/KGeoBag/Source/Shapes/External/Source/happly.h
@@ -50,6 +50,7 @@ SOFTWARE.
 
 #include <array>
 #include <cctype>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <limits>
@@ -951,7 +952,7 @@ public:
 
     // Find the property
     std::unique_ptr<Property>& prop = getPropertyPtr(propertyName);
-    TypedProperty<T>* castedProp = dynamic_cast<TypedProperty<T>*>(prop);
+    TypedProperty<T>* castedProp = dynamic_cast<TypedProperty<T>*>(prop.get());
     if (castedProp) {
       return castedProp->data;
     }
@@ -994,7 +995,7 @@ public:
 
     // Find the property
     std::unique_ptr<Property>& prop = getPropertyPtr(propertyName);
-    TypedListProperty<T>* castedProp = dynamic_cast<TypedListProperty<T>*>(prop);
+    TypedListProperty<T>* castedProp = dynamic_cast<TypedListProperty<T>*>(prop.get());
     if (castedProp) {
       return unflattenList(castedProp->flattenedData, castedProp->flattenedIndexStart);
     }

--- a/Kassiopeia/Objects/Include/KSObject.h
+++ b/Kassiopeia/Objects/Include/KSObject.h
@@ -8,6 +8,16 @@
 namespace Kassiopeia
 {
 
+#if defined(__GNUC__) || defined(__clang__)
+// GCC 15 can report a false -Wuninitialized path when this template is inlined into
+// component constructors; keep Set(...) out-of-line at call sites to avoid that path.
+// Found with Set<...>(this) in the constructor of KSMagneticField, where "this" being
+// potentially not fully initialized caused the above issue.
+#define KSOBJECT_NOINLINE __attribute__((noinline))
+#else
+#define KSOBJECT_NOINLINE
+#endif
+
 class KSObject : public katrin::KTagged
 {
   public:
@@ -28,7 +38,7 @@ class KSObject : public katrin::KTagged
     template<class XType> const XType* As() const;
 
   protected:
-    template<class XType> void Set(XType*);
+    template<class XType> KSOBJECT_NOINLINE void Set(XType*);
 
   private:
     class KSHolder
@@ -54,7 +64,7 @@ class KSObject : public katrin::KTagged
         XType* fObject;
     };
 
-    mutable std::unique_ptr<KSHolder> fHolder;
+    mutable std::unique_ptr<KSHolder> fHolder = nullptr;
 };
 
 inline KSObject::KSHolder::KSHolder() = default;
@@ -70,6 +80,9 @@ template<class XType> inline void KSObject::KSHolderTemplate<XType>::Type()
 
 template<class XType> inline bool KSObject::Is()
 {
+    if(!fHolder) {
+        return false;
+    }
     try {
         fHolder->Type();
     }
@@ -88,6 +101,9 @@ template<> inline bool KSObject::Is<KSObject>()
 
 template<class XType> inline bool KSObject::Is() const
 {
+    if(!fHolder) {
+        return false;
+    }
     try {
         fHolder->Type();
     }
@@ -106,6 +122,9 @@ template<> inline bool KSObject::Is<KSObject>() const
 
 template<class XType> inline XType* KSObject::As()
 {
+    if(!fHolder) {
+        return nullptr;
+    }
     try {
         fHolder->Type();
     }
@@ -124,6 +143,9 @@ template<> inline KSObject* KSObject::As<KSObject>()
 
 template<class XType> inline const XType* KSObject::As() const
 {
+    if(!fHolder) {
+        return nullptr;
+    }
     try {
         fHolder->Type();
     }
@@ -140,7 +162,7 @@ template<> inline const KSObject* KSObject::As<KSObject>() const
     return this;
 }
 
-template<class XType> inline void KSObject::Set(XType* anObject)
+template<class XType> KSOBJECT_NOINLINE void KSObject::Set(XType* anObject)
 {
     auto* tHolder = new KSHolderTemplate<XType>(anObject);
     fHolder = std::unique_ptr<KSHolder>(tHolder);
@@ -148,5 +170,7 @@ template<class XType> inline void KSObject::Set(XType* anObject)
 }
 
 }  // namespace Kassiopeia
+
+#undef KSOBJECT_NOINLINE
 
 #endif


### PR DESCRIPTION
The GCC version shipped with Fedora 42 threw more warnings treated as errors that required some minor fixes.

---

I updated the contained version of `happly` and due to compiler error added an include that since then was also merged upstream: https://github.com/nmwsharp/happly/pull/58

---

Also notably, there exists this line:

https://github.com/KATRIN-Experiment/Kassiopeia/blob/8ca81638cfac228d5eee4666942f8287de812061/Kassiopeia/Objects/Include/KSComponentTemplate.h#L24

Here, in the constructor of `KSComponentTemplate.h`, `KSComponentTemplate` gets a pointer to itself set to a holder structure within itself with the type it holds, which is done to store the corresponding type information. I feel like this is a bit convoluted, but it is a trick with templating, so that's maybe normal. In any case the compiler complains that `this` is not fully constructed when `Set` is called, which is inherent to this design. This is fixed by avoiding the inlining of the `Set` method, which was found by Copilot.

---

Btw. I did not update to Fedora 43 since for whatever reason then the full Docker image booted in JupyterHub can no longer show Kassiopeia visualizations since surfaces are then just rendered black and vanish as soon as one rotates the view.