### PR TITLE
CI: Test Clang on Fedora

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
   fedora_40:
     strategy:
       matrix:
-        use_clang: [false] # FIXME add "true" after solving https://github.com/KATRIN-Experiment/Kassiopeia/issues/87 
+        use_clang: [false, true]
     runs-on: ubuntu-latest
     container: fedora:40
     steps:

--- a/KEMField/Source/Applications/Calculation/ComputeChargeDensities.cc
+++ b/KEMField/Source/Applications/Calculation/ComputeChargeDensities.cc
@@ -426,12 +426,7 @@ void ReadInTriangles(const std::string& fileName, KSurfaceContainer& surfaceCont
     getline(file, inBuf);
     token = Tokenize(" \t", inBuf);
 
-    int lineNum = 0;
-
-    int counter = 0;
-
     while (!file.eof()) {
-        lineNum++;
         if (!token.empty()) {
             if (token.at(0).at(0) == '#') {
                 getline(file, inBuf);
@@ -487,7 +482,6 @@ void ReadInTriangles(const std::string& fileName, KSurfaceContainer& surfaceCont
 
                     surfaceContainer.push_back(t);
                 }
-                counter++;
             }
         }
         getline(file, inBuf);
@@ -510,12 +504,7 @@ void ReadInRectangles(const std::string& fileName, KSurfaceContainer& surfaceCon
     getline(file, inBuf);
     token = Tokenize(" \t", inBuf);
 
-    int lineNum = 0;
-
-    int counter = 0;
-
     while (!file.eof()) {
-        lineNum++;
         if (!token.empty()) {
             if (token.at(0).at(0) == '#') {
                 getline(file, inBuf);
@@ -569,7 +558,6 @@ void ReadInRectangles(const std::string& fileName, KSurfaceContainer& surfaceCon
 
                     surfaceContainer.push_back(t);
                 }
-                counter++;
             }
         }
         getline(file, inBuf);
@@ -591,12 +579,7 @@ void ReadInWires(const std::string& fileName, KSurfaceContainer& surfaceContaine
     getline(file, inBuf);
     token = Tokenize(" \t", inBuf);
 
-    int lineNum = 0;
-
-    int counter = 0;
-
     while (!file.eof()) {
-        lineNum++;
         if (!token.empty()) {
             if (token.at(0).at(0) == '#') {
                 getline(file, inBuf);
@@ -635,7 +618,6 @@ void ReadInWires(const std::string& fileName, KSurfaceContainer& surfaceContaine
 
                     surfaceContainer.push_back(t);
                 }
-                counter++;
             }
         }
         getline(file, inBuf);

--- a/KEMField/Source/Applications/Calculation/ComputePlateCapacitor.cc
+++ b/KEMField/Source/Applications/Calculation/ComputePlateCapacitor.cc
@@ -917,7 +917,6 @@ int main(int argc, char* argv[])
 
         double center_frac = 10.;
 
-        unsigned int i = 0;
         for (KSurfaceContainer::iterator it = surfaceContainer.begin(); it != surfaceContainer.end(); it++) {
             double _Q = ((*it)->GetShape()->Area() * dynamic_cast<KElectrostaticBasis*>(*it)->GetSolution());
             if ((*it)->GetShape()->Centroid().Z() <= distance1 + distance2 / 2.) {
@@ -935,7 +934,6 @@ int main(int argc, char* argv[])
                 if ((*it)->GetShape()->Centroid().Perp() <= radius / center_frac)
                     Q_3_cen += _Q;
             }
-            i++;
         }
 
         Q_computed = Q_1 + Q_2 + Q_3;
@@ -1321,13 +1319,9 @@ void ReadInTriangles(const std::string& fileName, KSurfaceContainer& surfaceCont
     //getline(file, inBuf);
     //token = Tokenize(" \t", inBuf);
 
-    int lineNum = 0;
-    int counter = 0;
-
     while (getline(file, inBuf)){
         token = Tokenize(" \t", inBuf);
 
-        lineNum++;
         if (!token.empty()) {
             if (token.at(0).at(0) == '#') {
                 //getline(file, inBuf);
@@ -1381,7 +1375,6 @@ void ReadInTriangles(const std::string& fileName, KSurfaceContainer& surfaceCont
 
                     surfaceContainer.push_back(t);
                 }
-                counter++;
             }
         }
         //getline(file, inBuf);

--- a/KEMField/Source/Applications/Calculation/ComputeSphericalCapacitor.cc
+++ b/KEMField/Source/Applications/Calculation/ComputeSphericalCapacitor.cc
@@ -1030,7 +1030,6 @@ int main(int argc, char* argv[])
         Q_2 = 0.;
         Q_3 = 0.;
 
-        unsigned int i = 0;
         for (KSurfaceContainer::iterator it = surfaceContainer.begin(); it != surfaceContainer.end(); it++) {
             if ((*it)->GetShape()->Centroid().Magnitude() < .5 * (radius1 + radius2))
                 Q_1 += ((*it)->GetShape()->Area() * dynamic_cast<KElectrostaticBasis*>(*it)->GetSolution());
@@ -1038,7 +1037,6 @@ int main(int argc, char* argv[])
                 Q_2 += ((*it)->GetShape()->Area() * dynamic_cast<KElectrostaticBasis*>(*it)->GetSolution());
             else
                 Q_3 += ((*it)->GetShape()->Area() * dynamic_cast<KElectrostaticBasis*>(*it)->GetSolution());
-            i++;
         }
 
         Q_computed = Q_1 + Q_2 + Q_3;
@@ -1416,13 +1414,9 @@ void ReadInTriangles(const std::string& fileName, KSurfaceContainer& surfaceCont
     //getline(file, inBuf);
     //token = Tokenize(" \t", inBuf);
 
-    int lineNum = 0;
-    int counter = 0;
-
     while (getline(file, inBuf)){
         token = Tokenize(" \t", inBuf);
 
-        lineNum++;
         if (!token.empty()) {
             if (token.at(0).at(0) == '#') {
                 //getline(file, inBuf);
@@ -1476,7 +1470,6 @@ void ReadInTriangles(const std::string& fileName, KSurfaceContainer& surfaceCont
 
                     surfaceContainer.push_back(t);
                 }
-                counter++;
             }
         }
         //getline(file, inBuf);

--- a/KEMField/Source/FastMultipole/Electrostatics/src/KFMElectrostaticMultipoleCalculatorAnalytic.cc
+++ b/KEMField/Source/FastMultipole/Electrostatics/src/KFMElectrostaticMultipoleCalculatorAnalytic.cc
@@ -503,7 +503,7 @@ void KFMElectrostaticMultipoleCalculatorAnalytic::TranslateMomentsAlongZ(
     std::vector<std::complex<double>>& source_moments, std::vector<std::complex<double>>& target_moments) const
 {
     //compute the array of powers of r
-    double r_pow[fDegree + 1];
+    std::vector<double> r_pow(static_cast<size_t>(fDegree) + 1);
     r_pow[0] = 1.0;
     for (int i = 1; i <= fDegree; i++) {
         r_pow[i] = fDelMag * r_pow[i - 1];

--- a/KEMField/Source/Math/Utilities/src/KFMMath.cc
+++ b/KEMField/Source/Math/Utilities/src/KFMMath.cc
@@ -1,6 +1,7 @@
 #include "KFMMath.hh"
 
 #include <cstdlib>
+#include <vector>
 
 namespace KEMField
 {
@@ -1061,19 +1062,19 @@ void KFMMath::RegularSolidHarmonic_Cart_Array(int n_max, const double* cartesian
     double r = KFMMath::Radius(cartesian_coords);
 
     //compute the array of powers of r
-    double r_pow[n_max + 1];
+    std::vector<double> r_pow(static_cast<size_t>(n_max) + 1);
     r_pow[0] = 1.0;
     for (int i = 1; i <= n_max; i++) {
         r_pow[i] = r * r_pow[i - 1];
     }
 
     //compute alp array
-    double plm[max_size];
-    KFMMath::ALP_nm_array(n_max, cosTheta, plm);
+    std::vector<double> plm(max_size);
+    KFMMath::ALP_nm_array(n_max, cosTheta, plm.data());
 
     //compute the array of cos(m*x) and sin(m*x)
-    double cos_vec[n_max + 1];
-    double sin_vec[n_max + 1];
+    std::vector<double> cos_vec(static_cast<size_t>(n_max) + 1);
+    std::vector<double> sin_vec(static_cast<size_t>(n_max) + 1);
 
     //intial values needed for recursion
     double sin = std::sin(phi);
@@ -1131,19 +1132,19 @@ void KFMMath::IrregularSolidHarmonic_Cart_Array(int n_max, const double* cartesi
     double inv_r = 1.0 / KFMMath::Radius(cartesian_coords);
 
     //compute the array of powers of r
-    double r_pow[n_max + 1];
+    std::vector<double> r_pow(static_cast<size_t>(n_max) + 1);
     r_pow[0] = inv_r;
     for (int i = 1; i <= n_max; i++) {
         r_pow[i] = inv_r * r_pow[i - 1];
     }
 
     //compute alp array
-    double plm[max_size];
-    KFMMath::ALP_nm_array(n_max, cosTheta, plm);
+    std::vector<double> plm(max_size);
+    KFMMath::ALP_nm_array(n_max, cosTheta, plm.data());
 
     //compute the array of cos(m*x) and sin(m*x)
-    double cos_vec[n_max + 1];
-    double sin_vec[n_max + 1];
+    std::vector<double> cos_vec(static_cast<size_t>(n_max) + 1);
+    std::vector<double> sin_vec(static_cast<size_t>(n_max) + 1);
 
     //intial values needed for recursion
     double sin = std::sin(phi);

--- a/KEMField/Source/Plugins/Root/src/KEMRootFieldCanvas.cc
+++ b/KEMField/Source/Plugins/Root/src/KEMRootFieldCanvas.cc
@@ -12,6 +12,8 @@
 #include "TStyle.h"
 
 #include <cmath>
+#include <stdexcept>
+#include <vector>
 
 namespace KEMField
 {
@@ -59,26 +61,38 @@ void KEMRootFieldCanvas::DrawGeomRZ(const std::string& conicSectfile, const std:
 {
     // Read in the conicSects
 
-    int __attribute__((unused)) _ret;
-
     if (conicSectfile != "NULL") {
         FILE* inputfull = fopen(conicSectfile.c_str(), "r");
 
         int NconicSect;
 
-        _ret = fscanf(inputfull, "%i", &NconicSect);
+        int _ret = fscanf(inputfull, "%i", &NconicSect);
 
-        TLine* eline[NconicSect];
+        if (_ret != 1) {
+            throw std::runtime_error("Could not read NconicSect");
+        }
 
-        double ex_0[NconicSect];
-        double ey_0[NconicSect];
-        double ex_1[NconicSect];
-        double ey_1[NconicSect];
+        if (NconicSect < 0) {
+            throw std::runtime_error("NconicSect must be positive");
+        }
+
+        size_t nConicSect = static_cast<size_t>(NconicSect);
+        std::vector<TLine*> eline(nConicSect);
+
+        std::vector<double> ex_0(nConicSect);
+        std::vector<double> ey_0(nConicSect);
+        std::vector<double> ex_1(nConicSect);
+        std::vector<double> ey_1(nConicSect);
         double temp1;
         int temp2;
 
         for (int s = 0; s < NconicSect; s++) {
-            _ret = fscanf(inputfull, "%le %le %le %le %le %i", &ex_0[s], &ey_0[s], &ex_1[s], &ey_1[s], &temp1, &temp2);
+            int _ret = fscanf(inputfull, "%le %le %le %le %le %i", &ex_0[s], &ey_0[s], &ex_1[s], &ey_1[s], &temp1, &temp2);
+
+            if (_ret < 4 || _ret > 6) {
+                throw std::runtime_error("Could not read conic section");
+            }
+
             eline[s] = new TLine(ex_0[s], ey_0[s], ex_1[s], ey_1[s]);
         }
 
@@ -124,22 +138,31 @@ void KEMRootFieldCanvas::DrawGeomRZ(const std::string& conicSectfile, const std:
 
         int Nwire;
 
-        _ret = fscanf(inputwire, "%i", &Nwire);
+        int _ret = fscanf(inputwire, "%i", &Nwire);
 
-        TLine* wline[Nwire];
+        if (_ret != 1) {
+            throw std::runtime_error("Could not read Nwire");
+        }
 
-        double wx_0[Nwire];
-        double wy_0[Nwire];
-        double wx_1[Nwire];
-        double wy_1[Nwire];
-        double wd[Nwire];
+        if (Nwire < 0) {
+            throw std::runtime_error("Nwire must be positive");
+        }
+
+        size_t nWire = static_cast<size_t>(Nwire);
+        std::vector<TLine*> wline(nWire);
+
+        std::vector<double> wx_0(nWire);
+        std::vector<double> wy_0(nWire);
+        std::vector<double> wx_1(nWire);
+        std::vector<double> wy_1(nWire);
+        std::vector<double> wd(nWire);
         double temp3;
         int temp4;
         double temp5;
         int temp6;
 
         for (int s = 0; s < Nwire; s++) {
-            _ret = fscanf(inputwire,
+            int _ret = fscanf(inputwire,
                           "%le %le %le %le %le %le %i %le %i",
                           &wx_0[s],
                           &wy_0[s],
@@ -150,6 +173,11 @@ void KEMRootFieldCanvas::DrawGeomRZ(const std::string& conicSectfile, const std:
                           &temp4,
                           &temp5,
                           &temp6);
+            
+            if (_ret < 5 || _ret > 9) {
+                throw std::runtime_error("Could not read wire");
+            }
+
             wline[s] = new TLine(wx_0[s], wy_0[s], wx_1[s], wy_1[s]);
         }
 
@@ -197,18 +225,32 @@ void KEMRootFieldCanvas::DrawGeomRZ(const std::string& conicSectfile, const std:
 
         int Ncoil;
 
-        _ret = fscanf(inputcoil, "%i", &Ncoil);
+        int _ret = fscanf(inputcoil, "%i", &Ncoil);
 
-        TBox* box[Ncoil];
+        if (_ret != 1) {
+            throw std::runtime_error("Could not read Ncoil");
+        }
 
-        double z_mid[Ncoil];
-        double r_min[Ncoil];
-        double r_thk[Ncoil];
-        double z_len[Ncoil];
+        if (Ncoil < 0) {
+            throw std::runtime_error("Ncoil must be positive");
+        }
+
+        size_t nCoil = static_cast<size_t>(Ncoil);
+        std::vector<TBox*> box(nCoil);
+
+        std::vector<double> z_mid(nCoil);
+        std::vector<double> r_min(nCoil);
+        std::vector<double> r_thk(nCoil);
+        std::vector<double> z_len(nCoil);
         double temp;
 
         for (int j = 0; j < Ncoil; j++) {
-            _ret = fscanf(inputcoil, "%le %le %le %le %le ", &z_mid[j], &r_min[j], &r_thk[j], &z_len[j], &temp);
+            int _ret = fscanf(inputcoil, "%le %le %le %le %le ", &z_mid[j], &r_min[j], &r_thk[j], &z_len[j], &temp);
+            
+            if (_ret < 4 || _ret > 5) {
+                throw std::runtime_error("Could not read coil");
+            }
+            
             box[j] = new TBox((z_mid[j] - z_len[j] / 2), r_min[j], (z_mid[j] + z_len[j] / 2), (r_min[j] + r_thk[j]));
         }
 
@@ -241,26 +283,37 @@ void KEMRootFieldCanvas::DrawGeomXY(double z, const std::string& conicSectfile, 
 {
     // Read in the conicSects
 
-    int __attribute__((unused)) _ret;
-
     if (conicSectfile != "NULL") {
         FILE* inputfull = fopen(conicSectfile.c_str(), "r");
 
         int NconicSect;
 
-        _ret = fscanf(inputfull, "%i", &NconicSect);
+        int _ret = fscanf(inputfull, "%i", &NconicSect);
 
-        TEllipse* e[NconicSect];
+        if (_ret != 1) {
+            throw std::runtime_error("Could not read NconicSect");
+        }
 
-        double ez_0[NconicSect];
-        double er_0[NconicSect];
-        double ez_1[NconicSect];
-        double er_1[NconicSect];
+        if (NconicSect < 0) {
+            throw std::runtime_error("NconicSect must be positive");
+        }
+
+        size_t nConicSect = static_cast<size_t>(NconicSect);
+        std::vector<TEllipse*> e(nConicSect);
+
+        std::vector<double> ez_0(nConicSect);
+        std::vector<double> er_0(nConicSect);
+        std::vector<double> ez_1(nConicSect);
+        std::vector<double> er_1(nConicSect);
         double temp1;
         int temp2;
 
         for (int s = 0; s < NconicSect; s++) {
-            _ret = fscanf(inputfull, "%le %le %le %le %le %i", &ez_0[s], &er_0[s], &ez_1[s], &er_1[s], &temp1, &temp2);
+            int _ret = fscanf(inputfull, "%le %le %le %le %le %i", &ez_0[s], &er_0[s], &ez_1[s], &er_1[s], &temp1, &temp2);
+
+            if (_ret < 4 || _ret > 6) {
+                throw std::runtime_error("Could not read conic section");
+            }
 
             if (ez_0[s] < z && ez_1[s] > z) {
                 double z_tot = fabs(ez_1[s] - ez_0[s]);
@@ -284,22 +337,31 @@ void KEMRootFieldCanvas::DrawGeomXY(double z, const std::string& conicSectfile, 
 
         int Nwire;
 
-        _ret = fscanf(inputwire, "%i", &Nwire);
+        int _ret = fscanf(inputwire, "%i", &Nwire);
 
-        TEllipse* w[Nwire];
+        if (_ret != 1) {
+            throw std::runtime_error("Could not read Nwire");
+        }
 
-        double wz_0[Nwire];
-        double wr_0[Nwire];
-        double wz_1[Nwire];
-        double wr_1[Nwire];
-        double wd[Nwire];
-        double phi[Nwire];
-        int numwire[Nwire];
+        if (Nwire < 0) {
+            throw std::runtime_error("Nwire must be positive");
+        }
+
+        size_t nWire = static_cast<size_t>(Nwire);
+        std::vector<TEllipse*> w(nWire);
+
+        std::vector<double> wz_0(nWire);
+        std::vector<double> wr_0(nWire);
+        std::vector<double> wz_1(nWire);
+        std::vector<double> wr_1(nWire);
+        std::vector<double> wd(nWire);
+        std::vector<double> phi(nWire);
+        std::vector<int> numwire(nWire);
         double temp5;
         int temp6;
 
         for (int s = 0; s < Nwire; s++) {
-            _ret = fscanf(inputwire,
+            int _ret = fscanf(inputwire,
                           "%le %le %le %le %le %le %i %le %i",
                           &wz_0[s],
                           &wr_0[s],
@@ -310,6 +372,10 @@ void KEMRootFieldCanvas::DrawGeomXY(double z, const std::string& conicSectfile, 
                           &numwire[s],
                           &temp5,
                           &temp6);
+            
+            if (_ret < 7 || _ret > 9) {
+                throw std::runtime_error("Could not read wire");
+            }
 
             double z_tot = fabs(wz_1[s] - wz_0[s]);
 
@@ -351,18 +417,32 @@ void KEMRootFieldCanvas::DrawGeomXY(double z, const std::string& conicSectfile, 
 
         int Ncoil;
 
-        _ret = fscanf(inputcoil, "%i", &Ncoil);
+        int _ret = fscanf(inputcoil, "%i", &Ncoil);
 
-        TEllipse* coil[Ncoil];
+        if (_ret != 1) {
+            throw std::runtime_error("Could not read Ncoil");
+        }
 
-        double z_mid[Ncoil];
-        double r_min[Ncoil];
-        double r_thk[Ncoil];
-        double z_len[Ncoil];
+        if (Ncoil < 0) {
+            throw std::runtime_error("Ncoil must be positive");
+        }
+
+        size_t nCoil = static_cast<size_t>(Ncoil);
+        std::vector<TEllipse*> coil(nCoil);
+
+        std::vector<double> z_mid(nCoil);
+        std::vector<double> r_min(nCoil);
+        std::vector<double> r_thk(nCoil);
+        std::vector<double> z_len(nCoil);
         double temp;
 
         for (int j = 0; j < Ncoil; j++) {
-            _ret = fscanf(inputcoil, "%le %le %le %le %le ", &z_mid[j], &r_min[j], &r_thk[j], &z_len[j], &temp);
+            int _ret = fscanf(inputcoil, "%le %le %le %le %le ", &z_mid[j], &r_min[j], &r_thk[j], &z_len[j], &temp);
+            
+            if (_ret < 4 || _ret > 5) {
+                throw std::runtime_error("Could not read coil");
+            }
+            
             if (z_mid[j] + z_len[j] / 2 > z && z_mid[j] - z_len[j] / 2 < z) {
                 coil[j] = new TEllipse(0, 0, r_min[j] + r_thk[j], r_min[j]);
                 coil[j]->SetLineWidth(0);
@@ -458,7 +538,8 @@ void KEMRootFieldCanvas::DrawFieldLines(const std::vector<double>& x, const std:
 {
     int nLineSegs = x.size() - 1;
 
-    TLine* fl[nLineSegs];
+    size_t nLineSegsSize = nLineSegs > 0 ? static_cast<size_t>(nLineSegs) : 0;
+    std::vector<TLine*> fl(nLineSegsSize);
 
     for (int n = 0; n < nLineSegs; n++) {
         fl[n] = new TLine(x[n], y[n], x[n + 1], y[n + 1]);

--- a/KGeoBag/Source/Visualization/Vtk/Source/KGVTKMeshPainter.cc
+++ b/KGeoBag/Source/Visualization/Vtk/Source/KGVTKMeshPainter.cc
@@ -205,9 +205,7 @@ void KGVTKMeshPainter::PaintElements()
     unsigned int tMod = 0;
     const unsigned int tModBase = 13;
 
-    unsigned int count = 0;
     for (auto* element : *fCurrentElements) {
-        count++;
 
         if (auto* tMeshRectangle = dynamic_cast<KGMeshRectangle*>(element)) {
             KThreeVector tPoint0 = fCurrentOrigin + tMeshRectangle->GetP0().X() * fCurrentXAxis +

--- a/Kassiopeia/Applications/Examples/Source/MultiFileAnalysis.cxx
+++ b/Kassiopeia/Applications/Examples/Source/MultiFileAnalysis.cxx
@@ -16,8 +16,8 @@ int main()
 {
 
     int term_max_step_count = 0;
-    int term_max_r_count = 0;
-    int term_minmax_z_count = 0;
+    //int term_max_r_count = 0;
+    //int term_minmax_z_count = 0;
 
     std::vector<double> term_times;
 
@@ -101,10 +101,10 @@ int main()
                             final_ke_values.push_back(tFKE.Value());
                         }
                         else if (tTerm.Value() == "term_max_r") {
-                            term_max_r_count++;
+                            //term_max_r_count++;
                         }
                         else if (tTerm.Value() == "term_max_z" || tTerm.Value() == "term_min_z") {
-                            term_minmax_z_count++;
+                            //term_minmax_z_count++;
                         }
                         else {
                             std::cout << "Error: bad terminator name.\n";

--- a/Kassiopeia/Navigators/Source/KSNavMeshedSpace.cxx
+++ b/Kassiopeia/Navigators/Source/KSNavMeshedSpace.cxx
@@ -539,7 +539,6 @@ void KSNavMeshedSpace::CalculateNavigation(const KSTrajectory& aTrajectory,
         stopIt++;
 
         unsigned int repeatCount = 0;
-        unsigned int seg = 0;
         while (stopIt != fIntermediateParticleStates.end()) {
             tInitialPoint = startIt->GetPosition();
             tFinalPoint = stopIt->GetPosition();
@@ -747,8 +746,6 @@ void KSNavMeshedSpace::CalculateNavigation(const KSTrajectory& aTrajectory,
 
                         break;
                 };
-
-                seg++;
 
                 if (validIntersection)  //intersection is not a repeat of the last
                 {

--- a/Kassiopeia/Visualization/Source/KSROOTTrackPainter.cxx
+++ b/Kassiopeia/Visualization/Source/KSROOTTrackPainter.cxx
@@ -8,6 +8,7 @@
 #include "TStyle.h"
 
 #include <limits>
+#include <vector>
 
 using namespace katrin;
 using namespace std;
@@ -577,10 +578,10 @@ void KSROOTTrackPainter::CreateColors(KSReadFileROOT& aReader)
         int tColorBins = 100;
         size_t tNumberBaseColors = fBaseColors.size();
 
-        double tRed[tNumberBaseColors];
-        double tGreen[tNumberBaseColors];
-        double tBlue[tNumberBaseColors];
-        double tFraction[tNumberBaseColors];
+        std::vector<double> tRed(tNumberBaseColors);
+        std::vector<double> tGreen(tNumberBaseColors);
+        std::vector<double> tBlue(tNumberBaseColors);
+        std::vector<double> tFraction(tNumberBaseColors);
 
         for (size_t tIndex = 0; tIndex < tNumberBaseColors; tIndex++) {
             tRed[tIndex] = fBaseColors.at(tIndex).first.GetRed();
@@ -592,7 +593,8 @@ void KSROOTTrackPainter::CreateColors(KSReadFileROOT& aReader)
             }
         }
 
-        int tMinColor = TColor::CreateGradientColorTable(tNumberBaseColors, tFraction, tRed, tGreen, tBlue, tColorBins);
+        int tMinColor = TColor::CreateGradientColorTable(
+            static_cast<int>(tNumberBaseColors), tFraction.data(), tRed.data(), tGreen.data(), tBlue.data(), tColorBins);
         int tMaxColor = tMinColor + tColorBins - 1;
 
         if (fColorPalette == eColorDefault) {

--- a/UnitTest/KEMField/Fields/src/DielectricsTest.cc
+++ b/UnitTest/KEMField/Fields/src/DielectricsTest.cc
@@ -88,9 +88,8 @@ class KEMFieldDielectricsTest : public KEMFieldTest
    */
     void AddRect(KSurfaceContainer& fContainer, int& fGroup, int& fChDen, double fA, double fB, KFieldVector fP0,
                  KFieldVector fN1, KFieldVector fN2, double fU, /* potential */
-                 double fNRot, int fNumDiscA, int fNumDiscB)
+                 double /*fNRot*/, int fNumDiscA, int fNumDiscB)
     {
-        fNRot++;
         fChDen += (fNumDiscA * fNumDiscB);
 
         // do not discretize if discretization parameters are set to 0
@@ -165,9 +164,8 @@ class KEMFieldDielectricsTest : public KEMFieldTest
    * constant charge density is more reasonable.
    */
     void AddWire(KSurfaceContainer& fContainer, int& fGroup, int& fChDen, KPosition fPA, KPosition fPB,
-                 double fD /*diameter*/, double fU /*potential*/, int fNRot, int fNumDisc)
+                 double fD /*diameter*/, double fU /*potential*/, int /*fNRot*/, int fNumDisc)
     {
-        (void) fNRot;
         fChDen += fNumDisc;
 
         // do not discretize if discretization parameter is set to 0
@@ -250,9 +248,8 @@ class KEMFieldDielectricsTest : public KEMFieldTest
 
     void AddBoundary(KSurfaceContainer& fContainer, int& fGroup, int& fChDen, double fA, double fB,
                      const KFieldVector& fP0, const KFieldVector& fN1, const KFieldVector& fN2, double fEpsRAbove,
-                     double fEpsRBelow, double fNRot, int fNumDiscA, int fNumDiscB)
+                     double fEpsRBelow, double /*fNRot*/, int fNumDiscA, int fNumDiscB)
     {
-        (void) fNRot;
         fChDen += (fNumDiscA * fNumDiscB);
 
         // do not discretize if discretization parameters are set to 0


### PR DESCRIPTION
This was not possible before #87 due to issues with GoogleTest.

Clang found unused variables and errors of type `error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]` that are both fixed in this commit.