### PR TITLE
Documentation: Fix macOS dependencies

### DIFF
--- a/Documentation/gh-pages/source/setup_manual.rst
+++ b/Documentation/gh-pages/source/setup_manual.rst
@@ -108,6 +108,7 @@ macOS
 On a macOS system, the packages can be installed using Homebrew (https://brew.sh/):
 
 .. code-block:: bash
+
     brew install \
         cmake \
         coreutils \


### PR DESCRIPTION
`brew` command was not rendered due to a missing empty line

Before: https://katrin-experiment.github.io/Kassiopeia/setup_manual.html#macos
After: https://2xB.github.io/Kassiopeia/setup_manual.html#macos