### PR TITLE
Fix VTK 9.7 deprecation warning

### DIFF
--- a/KEMField/Source/Plugins/VTK/include/KVTKIterationPlotter.hh
+++ b/KEMField/Source/Plugins/VTK/include/KVTKIterationPlotter.hh
@@ -83,7 +83,7 @@ template<typename ValueType> void KVTKIterationPlotter<ValueType>::CreatePlot()
 #endif
     dots->SetColor(0, 0, 0, 255);
 
-    if (fArrayX->GetSize() >= 2) {
+    if (fArrayX->GetCapacity() >= 2) {
         vtkPlot* line = fChart->AddPlot(vtkChart::LINE);
 #if VTK_MAJOR_VERSION <= 5
         line->SetInput(table, 0, 1);

--- a/KEMField/Source/Plugins/VTK/include/KVTKIterationPlotter.hh
+++ b/KEMField/Source/Plugins/VTK/include/KVTKIterationPlotter.hh
@@ -16,6 +16,7 @@
 #include <vtkSmartPointer.h>
 #include <vtkTable.h>
 #include <vtkVersion.h>
+#include <vtkVersionMacros.h>
 
 namespace KEMField
 {
@@ -82,8 +83,11 @@ template<typename ValueType> void KVTKIterationPlotter<ValueType>::CreatePlot()
     dots->SetInputData(table, 0, 1);
 #endif
     dots->SetColor(0, 0, 0, 255);
-
+#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 7, 0)
     if (fArrayX->GetCapacity() >= 2) {
+#else
+    if (fArrayX->GetSize() >= 2) {
+#endif
         vtkPlot* line = fChart->AddPlot(vtkChart::LINE);
 #if VTK_MAJOR_VERSION <= 5
         line->SetInput(table, 0, 1);

--- a/KEMField/Source/Plugins/VTK/include/KVTKIterationPlotter.hh
+++ b/KEMField/Source/Plugins/VTK/include/KVTKIterationPlotter.hh
@@ -16,7 +16,6 @@
 #include <vtkSmartPointer.h>
 #include <vtkTable.h>
 #include <vtkVersion.h>
-#include <vtkVersionMacros.h>
 
 namespace KEMField
 {
@@ -83,7 +82,7 @@ template<typename ValueType> void KVTKIterationPlotter<ValueType>::CreatePlot()
     dots->SetInputData(table, 0, 1);
 #endif
     dots->SetColor(0, 0, 0, 255);
-#if VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 7, 0)
+#if VTK_VERSION_NUMBER >= 90700000000ULL 
     if (fArrayX->GetCapacity() >= 2) {
 #else
     if (fArrayX->GetSize() >= 2) {


### PR DESCRIPTION
This fixes the GetSize() deprecation warning in VTK 9.7. This was discovered with our internal mac-os pipeline. Could be worthwile to add such a thing to the github actions as well. 

See https://docs.vtk.org/en/latest/release_details/9.7/add-vtkAbstractArray-reserve-and-capacity.html